### PR TITLE
Default compose pulls GHCR images with tag overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,23 @@ Images are built and pushed to GHCR via GitHub Actions as part of [`ci.yml`](.gi
 - `ghcr.io/<repo>/backend` (FastAPI + Uvicorn on port 8080)
 - `ghcr.io/<repo>/scraper` (RSS/HTML telemetry agent)
 
+`docker-compose.yml` references these images directly so `docker compose up` pulls from GHCR by default. Override the registry or
+tag without editing the file by exporting environment variables, for example:
+
+```bash
+VTOC_IMAGE_TAG=main docker compose up
+# or pin a preview build
+VTOC_IMAGE_REPO=ghcr.io/myfork/vtoc VTOC_IMAGE_TAG=pr-123 docker compose up
+```
+
+To build locally, call the container setup helper with `--build-local` so the generated compose file includes `build:` blocks:
+
+```bash
+./scripts/setup_container.sh --build-local
+```
+
+You can also select a published image tag during generation with `--image-tag <tag>` (equivalent to `VTOC_IMAGE_TAG`).
+
 A Fly.io dispatch workflow (`fly-deploy.yml`) deploys the backend using the prebuilt image when `live` receives new commits or
 when tags matching `v*` are pushed.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,8 @@ services:
       retries: 5
 
   backend:
-    build:
-      context: ./backend
+    image: ${VTOC_IMAGE_REPO:-ghcr.io/pr-cybr/vtoc}/backend:${VTOC_IMAGE_TAG:-main}
+    pull_policy: always
     environment:
       DATABASE_URL: postgresql+psycopg2://vtoc:vtocpass@database:5432/vtoc
       DATABASE_URL_TOC_S1: postgresql+psycopg2://vtoc:vtocpass@database:5432/vtoc?options=-csearch_path%3Dtoc_s1
@@ -32,16 +32,16 @@ services:
         condition: service_healthy
 
   frontend:
-    build:
-      context: ./frontend
+    image: ${VTOC_IMAGE_REPO:-ghcr.io/pr-cybr/vtoc}/frontend:${VTOC_IMAGE_TAG:-main}
+    pull_policy: always
     ports:
       - "8081:8081"
     depends_on:
       - backend
 
   scraper:
-    build:
-      context: ./agents/scraper
+    image: ${VTOC_IMAGE_REPO:-ghcr.io/pr-cybr/vtoc}/scraper:${VTOC_IMAGE_TAG:-main}
+    pull_policy: always
     environment:
       BACKEND_BASE_URL: http://backend:8080
     depends_on:

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -70,6 +70,16 @@ make setup-container
 make compose-up
 ```
 
+The generated compose file pulls prebuilt images from GHCR by default. To pin a specific tag, set `VTOC_IMAGE_TAG` (or pass
+`--image-tag` to `scripts/setup_container.sh`). For example:
+
+```bash
+VTOC_IMAGE_TAG=main docker compose up
+```
+
+If you need to build services locally, regenerate the compose file with `./scripts/setup_container.sh --build-local` so the
+`build:` blocks are reinstated.
+
 ### 4. Verify installation
 
 ```bash

--- a/scripts/setup_container.sh
+++ b/scripts/setup_container.sh
@@ -1,12 +1,58 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+usage() {
+  cat <<'USAGE'
+Usage: setup_container.sh [--pull] [--image-tag <tag>] [--build-local]
+
+Options:
+  --pull             Generate services that pull prebuilt images from GHCR (default)
+  --image-tag <tag>  Use the specified image tag when pulling from GHCR
+  --build-local      Use local Docker build contexts instead of pulling images
+  -h, --help         Show this help message
+USAGE
+}
+
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 OUTPUT_FILE="$ROOT_DIR/docker-compose.generated.yml"
 CONFIG_JSON="${VTOC_CONFIG_JSON:-{}}"
 APPLY="${VTOC_SETUP_APPLY:-false}"
+IMAGE_TAG="${VTOC_IMAGE_TAG:-main}"
+IMAGE_REPO="${VTOC_IMAGE_REPO:-ghcr.io/pr-cybr/vtoc}"
+USE_BUILD_LOCAL="${VTOC_BUILD_LOCAL:-false}"
 
-export ROOT_DIR OUTPUT_FILE CONFIG_JSON
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pull)
+      USE_BUILD_LOCAL="false"
+      shift
+      ;;
+    --image-tag)
+      if [[ $# -lt 2 ]]; then
+        echo "--image-tag requires a value" >&2
+        exit 1
+      fi
+      IMAGE_TAG="$2"
+      USE_BUILD_LOCAL="false"
+      shift 2
+      ;;
+    --build-local)
+      USE_BUILD_LOCAL="true"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+export ROOT_DIR OUTPUT_FILE CONFIG_JSON IMAGE_TAG IMAGE_REPO USE_BUILD_LOCAL
 
 python - <<'PY'
 import json
@@ -17,6 +63,9 @@ root_dir = Path(os.environ['ROOT_DIR'])
 output_file = Path(os.environ['OUTPUT_FILE'])
 config_json = os.environ.get('CONFIG_JSON', '{}')
 config = json.loads(config_json)
+image_repo = os.environ.get('IMAGE_REPO', 'ghcr.io/pr-cybr/vtoc')
+image_tag = os.environ.get('IMAGE_TAG', 'main')
+use_build_local = os.environ.get('USE_BUILD_LOCAL', 'false').lower() == 'true'
 services_config = config.get('services', {})
 
 postgres_enabled = services_config.get('postgres', True)
@@ -28,7 +77,6 @@ compose = {
     'version': '3.8',
     'services': {
         'backend': {
-            'build': {'context': './backend'},
             'ports': ['8080:8080'],
             'environment': {
                 'DATABASE_URL': 'postgresql+psycopg2://vtoc:vtocpass@database:5432/vtoc',
@@ -40,18 +88,28 @@ compose = {
             'depends_on': ['database'],
         },
         'frontend': {
-            'build': {'context': './frontend'},
             'ports': ['8081:8081'],
             'depends_on': ['backend'],
         },
         'scraper': {
-            'build': {'context': './agents/scraper'},
             'environment': {'BACKEND_BASE_URL': 'http://backend:8080'},
             'depends_on': ['backend'],
         },
     },
     'networks': {'default': {'driver': 'bridge'}},
 }
+
+if not use_build_local:
+    compose['services']['backend']['image'] = f"{image_repo}/backend:{image_tag}"
+    compose['services']['backend']['pull_policy'] = 'always'
+    compose['services']['frontend']['image'] = f"{image_repo}/frontend:{image_tag}"
+    compose['services']['frontend']['pull_policy'] = 'always'
+    compose['services']['scraper']['image'] = f"{image_repo}/scraper:{image_tag}"
+    compose['services']['scraper']['pull_policy'] = 'always'
+else:
+    compose['services']['backend']['build'] = {'context': './backend'}
+    compose['services']['frontend']['build'] = {'context': './frontend'}
+    compose['services']['scraper']['build'] = {'context': './agents/scraper'}
 
 if postgres_enabled:
     compose.setdefault('volumes', {})['postgres_data'] = {}


### PR DESCRIPTION
## Summary
- update scripts/setup_container.sh to support --image-tag, --pull, and --build-local flags and emit either GHCR images or local builds
- switch docker-compose.yml to pull ghcr.io/pr-cybr/vtoc images by default with overridable repo/tag variables
- document the new defaults, tag overrides, and local build workflow in README and docs/QUICKSTART.md

## Testing
- ./scripts/setup_container.sh --help
- ./scripts/setup_container.sh
- ./scripts/setup_container.sh --build-local

------
https://chatgpt.com/codex/tasks/task_e_68f01e4520508323b517f79a233b14b1