### PR TITLE
Adjust CI permissions and PR Docker behavior

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+permissions:
+  contents: read
+  packages: read
+
 on:
   push:
     branches: [main]
@@ -8,6 +12,8 @@ on:
 
 jobs:
   build-and-test:
+    permissions:
+      packages: ${{ github.event_name == 'push' && 'write' || 'read' }}
     runs-on: ubuntu-latest
     env:
       REGISTRY: ghcr.io
@@ -19,6 +25,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to GHCR
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -61,7 +68,14 @@ jobs:
       - name: Backend tests
         working-directory: backend
         run: pytest -q
+      - name: Set backend image tag (PR)
+        if: github.event_name == 'pull_request'
+        run: echo "BACKEND_IMAGE_TAG=vtoc-backend:pr-${{ github.sha }}" >> "$GITHUB_ENV"
+      - name: Set backend image tag (push)
+        if: github.event_name != 'pull_request'
+        run: echo "BACKEND_IMAGE_TAG=${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/backend:${{ github.sha }}" >> "$GITHUB_ENV"
       - name: Build backend image
+        if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v6
         with:
           context: ./backend
@@ -70,7 +84,17 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/backend:${{ github.sha }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/backend:latest
+      - name: Build backend image (PR)
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          push: false
+          load: true
+          tags: |
+            vtoc-backend:pr-${{ github.sha }}
       - name: Build frontend image
+        if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v6
         with:
           context: ./frontend
@@ -79,7 +103,17 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/frontend:${{ github.sha }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/frontend:latest
+      - name: Build frontend image (PR)
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          push: false
+          load: true
+          tags: |
+            vtoc-frontend:pr-${{ github.sha }}
       - name: Build scraper image
+        if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v6
         with:
           context: ./agents/scraper
@@ -88,10 +122,19 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/scraper:${{ github.sha }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/scraper:latest
+      - name: Build scraper image (PR)
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: ./agents/scraper
+          push: false
+          load: true
+          tags: |
+            vtoc-scraper:pr-${{ github.sha }}
       - name: Smoke test backend
         run: |
           docker run -d --rm -e DATABASE_URL=sqlite:/// -p 8080:8080 --name vtoc-backend-test \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/backend:${{ github.sha }}
+            "$BACKEND_IMAGE_TAG"
           sleep 5
           curl -f http://localhost:8080/healthz
           curl -f http://localhost:8080/api/v1/agent-actions/audits


### PR DESCRIPTION
## Summary
- declare explicit read-only workflow permissions and grant packages:write only on push events
- skip GHCR login and remote pushes for pull requests while building local images with `load: true`
- point the smoke test to the locally tagged backend image during PR workflows

## Testing
- not run (CI workflow updates only)

------
https://chatgpt.com/codex/tasks/task_e_68f047d480148323bc065f6f2835e98a