### PR TITLE
Simplify App routing to station dashboards

### DIFF
--- a/frontend/src/pages/App.tsx
+++ b/frontend/src/pages/App.tsx
@@ -48,40 +48,4 @@ const App = () => {
   );
 };
 
-const DashboardRoute = () => {
-  const { events, isLoading } = useOutletContext<LayoutContextValue>();
-
-  const markers = useMemo(() => {
-    return events.filter((event) => event.latitude && event.longitude);
-  }, [events]);
-
-  return (
-    <>
-      {isLoading && <p className="sr-only">Map is syncing telemetry…</p>}
-      <MapContainer center={DEFAULT_POSITION} zoom={8} scrollWheelZoom>
-        <TileLayer
-          url={import.meta.env.VITE_MAP_TILES_URL}
-          attribution={import.meta.env.VITE_MAP_ATTRIBUTION}
-        />
-        {markers.map((event) => (
-          <Marker key={event.id} position={[event.latitude!, event.longitude!] as LatLngExpression}>
-            <Popup>
-              <strong>{event.source.name}</strong>
-              <div>{new Date(event.event_time ?? event.received_at).toLocaleString()}</div>
-            </Popup>
-          </Marker>
-        ))}
-      </MapContainer>
-    </>
-  );
-};
-
-const App = () => (
-  <Routes>
-    <Route element={<AppLayout />}>
-      <Route index element={<DashboardRoute />} />
-    </Route>
-  </Routes>
-);
-
 export default App;


### PR DESCRIPTION
## Summary
- remove the obsolete AppLayout-based route wrapper from the App page
- retain only the station navigation routes and align the imports with the station dashboards

## Testing
- pnpm lint *(fails: Command "lint" not found)*
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68f0fe9cb56083238733f21f9e48594c