### PR TITLE
Remove duplicate BrowserRouter import in frontend entrypoint

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { BrowserRouter } from 'react-router-dom';
 import App from './pages/App';
 import './styles.css';
 


### PR DESCRIPTION
## Summary
- remove the redundant BrowserRouter import in frontend/src/main.tsx

## Testing
- pnpm lint (fails: Missing script: lint)


------
https://chatgpt.com/codex/tasks/task_e_68f0fea3151c83238617b6dac37b75bb