### PR TITLE
Update GitHub workflows to use live branch triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,9 @@ permissions:
 
 on:
   push:
-    branches: [main]
+    branches: [live]
   pull_request:
+    branches: [live]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -3,8 +3,8 @@ name: Fly Deploy
 on:
   workflow_dispatch:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - live
 
 jobs:
   deploy:

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -2,6 +2,8 @@ name: Preview Deploy
 
 on:
   pull_request:
+    branches:
+      - live
 
 jobs:
   check-pages-permissions:


### PR DESCRIPTION
## Summary
- retarget CI workflow triggers to the `live` branch for push and pull request events
- restrict Fly deploy and preview deploy workflows so they only run when `live` is involved

## Testing
- not run (workflow triggers updated only)


------
https://chatgpt.com/codex/tasks/task_e_68f0fea7b4bc8323a2cb0d548935b953