### PR TITLE
Add composite action for Codex CLI setup

### DIFF
--- a/.github/actions/setup-codex/README.md
+++ b/.github/actions/setup-codex/README.md
@@ -1,0 +1,41 @@
+# Setup Codex CLI action
+
+This composite action installs the Codex CLI and wires up authentication so subsequent workflow steps can call `codex` without additional configuration.
+
+## Inputs
+
+| Name | Required | Description |
+| ---- | -------- | ----------- |
+| `version` | No (default: `latest`) | Version of the Codex CLI to install. Provide an explicit semantic version (for example, `1.4.2`) or leave as `latest` to receive the newest published release. |
+| `api-key` | **Yes** | API key used by the Codex CLI for authentication. This should come from the `CODEX_API_KEY` repository secret. |
+| `base-url` | No | Override for the Codex API base URL. Useful when pointing at a self-hosted Codex deployment (for example, `${{ vars.CODEX_BASE_URL }}`). |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| `codex-path` | Absolute path to the installed `codex` executable added to `PATH`. |
+| `codex-version` | Version string reported by `codex --version`. |
+
+## Example
+
+```yaml
+steps:
+  - name: Check out repository
+    uses: actions/checkout@v4
+
+  - name: Setup Codex CLI
+    uses: ./.github/actions/setup-codex
+    with:
+      version: latest
+      api-key: ${{ secrets.CODEX_API_KEY }}
+      base-url: ${{ vars.CODEX_BASE_URL }}
+
+  - name: Summarize commits
+    run: codex chat --model gpt-4.1 --input "Summarize the recent changes"
+```
+
+## Required secrets and variables
+
+* `CODEX_API_KEY` — repository secret used to authenticate with Codex.
+* (Optional) `CODEX_BASE_URL` — repository variable used when the workflow targets a self-hosted Codex deployment instead of the default cloud endpoint.

--- a/.github/actions/setup-codex/action.yml
+++ b/.github/actions/setup-codex/action.yml
@@ -1,0 +1,63 @@
+name: Setup Codex CLI
+description: Install and configure the Codex CLI for downstream workflow steps.
+author: vTOC maintainers
+inputs:
+  version:
+    description: Codex CLI version to install. Use semantic version (for example, 1.2.3) or "latest" for the newest release.
+    required: false
+    default: latest
+  api-key:
+    description: Codex API key used to authenticate CLI calls.
+    required: true
+  base-url:
+    description: Optional Codex API base URL override.
+    required: false
+outputs:
+  codex-path:
+    description: Absolute path to the installed codex executable.
+    value: ${{ steps.codex-metadata.outputs.codex-path }}
+  codex-version:
+    description: Version string reported by the installed codex executable.
+    value: ${{ steps.codex-metadata.outputs.codex-version }}
+runs:
+  using: composite
+  steps:
+    - name: Export Codex environment variables
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo "CODEX_API_KEY=${{ inputs.api-key }}" >>"$GITHUB_ENV"
+        if [ -n "${{ inputs.base-url }}" ]; then
+          echo "CODEX_BASE_URL=${{ inputs.base-url }}" >>"$GITHUB_ENV"
+        fi
+
+    - name: Install Codex CLI
+      shell: bash
+      run: |
+        set -euo pipefail
+        VERSION="${{ inputs.version }}"
+        PIPX_BIN="$HOME/.local/bin/pipx"
+        python3 -m pip install --user --upgrade pipx
+        "$PIPX_BIN" ensurepath
+        echo "$HOME/.local/bin" >>"$GITHUB_PATH"
+        if [ -z "$VERSION" ] || [ "$VERSION" = "latest" ]; then
+          "$PIPX_BIN" install codex --force
+        else
+          "$PIPX_BIN" install "codex==$VERSION" --force
+        fi
+
+    - name: Capture Codex metadata
+      id: codex-metadata
+      shell: bash
+      run: |
+        set -euo pipefail
+        export PATH="$HOME/.local/bin:$PATH"
+        CODEX_BIN="$(command -v codex || true)"
+        if [ -z "$CODEX_BIN" ]; then
+          echo "Codex CLI is not available after installation." >&2
+          exit 1
+        fi
+        echo "CODEX_BIN=$CODEX_BIN" >>"$GITHUB_ENV"
+        CODEX_VERSION="$($CODEX_BIN --version | head -n 1 | tr -d '\r')"
+        echo "codex-path=$CODEX_BIN" >>"$GITHUB_OUTPUT"
+        echo "codex-version=$CODEX_VERSION" >>"$GITHUB_OUTPUT"

--- a/.github/workflows/main-discussion-summary.yml
+++ b/.github/workflows/main-discussion-summary.yml
@@ -16,7 +16,6 @@ jobs:
     container:
       image: python:3.11-slim
     env:
-      CODEX_API_KEY: ${{ secrets.CODEX_API_KEY }}
       CODEX_BASE_URL: ${{ vars.CODEX_BASE_URL }}
       DOCS_DISCUSSION_CATEGORY_ID: ${{ vars.DOCS_DISCUSSION_CATEGORY_ID }}
       DOCS_DISCUSSION_LABELS: ${{ vars.DOCS_DISCUSSION_LABELS }}
@@ -30,6 +29,12 @@ jobs:
           apt-get update
           apt-get install -y --no-install-recommends git curl
           rm -rf /var/lib/apt/lists/*
+
+      - name: Setup Codex CLI
+        uses: ./.github/actions/setup-codex
+        with:
+          api-key: ${{ secrets.CODEX_API_KEY }}
+          base-url: ${{ vars.CODEX_BASE_URL }}
 
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- add a reusable setup-codex composite action that installs the Codex CLI and exports authentication variables
- document the action inputs, outputs, and required repository secrets/variables
- update the main discussion summary workflow to consume the new action

## Testing
- not run (CI covers workflow syntax)


------
https://chatgpt.com/codex/tasks/task_e_68f1332ae288832391303f34afb6cc34