### PR TITLE
Automate Codex backlog planning workflow

### DIFF
--- a/.github/workflows/project-backlog-plan.yml
+++ b/.github/workflows/project-backlog-plan.yml
@@ -1,0 +1,364 @@
+name: Project backlog plan
+
+on:
+  projects_v2_item:
+    types:
+      - created
+      - edited
+
+permissions:
+  contents: write
+  pull-requests: read
+  projects: write
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Gather project item metadata
+        id: metadata
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PROJECTS_WORKFLOW_TOKEN != '' && secrets.PROJECTS_WORKFLOW_TOKEN || secrets.GITHUB_TOKEN }}
+          script: |
+            const item = context.payload.projects_v2_item;
+            if (!item) {
+              core.info('No project item in payload.');
+              core.setOutput('run', 'false');
+              return;
+            }
+
+            const itemNodeId = item.node_id;
+            if (!itemNodeId) {
+              core.info('Project item is missing a node ID.');
+              core.setOutput('run', 'false');
+              return;
+            }
+
+            const query = `
+              query($itemId: ID!) {
+                node(id: $itemId) {
+                  ... on ProjectV2Item {
+                    id
+                    project {
+                      id
+                      number
+                      title
+                      url
+                      fields(first: 50) {
+                        nodes {
+                          __typename
+                          ... on ProjectV2SingleSelectField {
+                            id
+                            name
+                            options {
+                              id
+                              name
+                            }
+                          }
+                        }
+                      }
+                    }
+                    fieldValues(first: 50) {
+                      nodes {
+                        __typename
+                        ... on ProjectV2ItemFieldSingleSelectValue {
+                          name
+                          optionId
+                          field {
+                            ... on ProjectV2SingleSelectField {
+                              name
+                            }
+                          }
+                        }
+                        ... on ProjectV2ItemFieldTextValue {
+                          text
+                          field {
+                            ... on ProjectV2FieldCommon {
+                              name
+                            }
+                          }
+                        }
+                        ... on ProjectV2ItemFieldNumberValue {
+                          number
+                          field {
+                            ... on ProjectV2FieldCommon {
+                              name
+                            }
+                          }
+                        }
+                        ... on ProjectV2ItemFieldDateValue {
+                          date
+                          field {
+                            ... on ProjectV2FieldCommon {
+                              name
+                            }
+                          }
+                        }
+                        ... on ProjectV2ItemFieldIterationValue {
+                          title
+                          startDate
+                          duration
+                          field {
+                            ... on ProjectV2IterationField {
+                              name
+                            }
+                          }
+                        }
+                      }
+                    }
+                    content {
+                      __typename
+                      ... on DraftIssue {
+                        title
+                        body
+                      }
+                      ... on Issue {
+                        title
+                        body
+                        number
+                        url
+                      }
+                      ... on PullRequest {
+                        title
+                        body
+                        number
+                        url
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+
+            const { node } = await github.graphql(query, { itemId: itemNodeId });
+            if (!node) {
+              core.info(`Unable to find project item with node ID ${itemNodeId}.`);
+              core.setOutput('run', 'false');
+              return;
+            }
+
+            const project = node.project;
+            if (!project) {
+              core.info('Project item is not attached to a project.');
+              core.setOutput('run', 'false');
+              return;
+            }
+
+            const fieldValues = node.fieldValues?.nodes ?? [];
+            const statusValue = fieldValues.find((value) => {
+              if (value?.__typename !== 'ProjectV2ItemFieldSingleSelectValue') {
+                return false;
+              }
+              const field = value.field;
+              return field?.name === 'Status';
+            });
+
+            const statusName = statusValue?.name ?? '';
+            const shouldRun = statusName === 'Backlog';
+            core.setOutput('run', shouldRun ? 'true' : 'false');
+            if (!shouldRun) {
+              core.info(`Skipping project item ${item.id} because status is '${statusName}'.`);
+              return;
+            }
+
+            const statusField = project.fields?.nodes?.find((field) => {
+              return field?.__typename === 'ProjectV2SingleSelectField' && field?.name === 'Status';
+            });
+
+            const readyOption = statusField?.options?.find((option) => option?.name === 'Ready');
+            if (!statusField || !readyOption) {
+              core.setFailed('Unable to resolve the Ready status option for the project.');
+              return;
+            }
+
+            const fieldSummaries = fieldValues.map((value) => {
+              const base = {
+                type: value?.__typename,
+              };
+
+              if (value?.field?.name) {
+                base.field = value.field.name;
+              }
+
+              if (value?.text) {
+                base.value = value.text;
+              } else if (value?.name) {
+                base.value = value.name;
+              } else if (typeof value?.number === 'number') {
+                base.value = value.number;
+              } else if (value?.date) {
+                base.value = value.date;
+              } else if (value?.title) {
+                base.value = value.title;
+              }
+
+              if (value?.optionId) {
+                base.optionId = value.optionId;
+              }
+
+              return base;
+            });
+
+            const content = node.content;
+            let contentData = null;
+            if (content) {
+              contentData = {
+                type: content.__typename,
+                title: content.title ?? null,
+                body: content.body ?? null,
+              };
+
+              if (typeof content.number !== 'undefined') {
+                contentData.number = content.number;
+              }
+
+              if (content.url) {
+                contentData.url = content.url;
+              }
+            }
+
+            const contextData = {
+              project_item_id: item.id ?? itemNodeId,
+              project_item_node_id: node.id,
+              project: {
+                id: project.id,
+                number: project.number,
+                title: project.title,
+                url: project.url,
+              },
+              status: statusName,
+              field_values: fieldSummaries,
+              content: contentData,
+            };
+
+            const base64Context = Buffer.from(JSON.stringify(contextData)).toString('base64');
+            core.setOutput('context_base64', base64Context);
+            core.setOutput('project_item_id', item.id ?? itemNodeId);
+            core.setOutput('project_item_node_id', node.id);
+            core.setOutput('status_field_id', statusField.id);
+            core.setOutput('ready_option_id', readyOption.id);
+            core.setOutput('project_id', project.id);
+
+      - name: Check out repository
+        if: steps.metadata.outputs.run == 'true'
+        uses: actions/checkout@v4
+
+      - name: Prepare backlog workspace
+        if: steps.metadata.outputs.run == 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p backlog
+
+      - name: Write backlog context
+        if: steps.metadata.outputs.run == 'true'
+        run: |
+          echo "${{ steps.metadata.outputs.context_base64 }}" | base64 --decode > backlog/context.json
+
+      - name: Set up Python
+        if: steps.metadata.outputs.run == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install planning dependencies
+        if: steps.metadata.outputs.run == 'true'
+        run: |
+          python -m pip install --upgrade pip
+          pip install PyYAML
+
+      - name: Install Codex CLI
+        if: steps.metadata.outputs.run == 'true'
+        uses: ./.github/actions/setup-codex
+        with:
+          api-key: ${{ secrets.CODEX_API_KEY }}
+          base-url: ${{ vars.CODEX_BASE_URL }}
+          version: ${{ vars.CODEX_CLI_VERSION }}
+
+      - name: Generate Codex plan
+        if: steps.metadata.outputs.run == 'true'
+        id: plan
+        run: |
+          python scripts/automation/backlog_plan.py \
+            --context backlog/context.json \
+            --backlog-file backlog/backlog.yaml \
+            --skip-if-exists \
+            --result backlog/plan-result.json
+
+      - name: Capture plan result
+        if: steps.metadata.outputs.run == 'true'
+        id: plan_result
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = 'backlog/plan-result.json';
+            let raw = '';
+            let skipped = false;
+            let planUrl = '';
+            if (fs.existsSync(path)) {
+              try {
+                raw = fs.readFileSync(path, 'utf8');
+                const data = JSON.parse(raw || '{}');
+                skipped = !!data.skipped;
+                planUrl = data.plan_url || '';
+              } catch (error) {
+                core.warning(`Failed to read plan result: ${error}`);
+              }
+            } else {
+              core.warning(`${path} was not generated.`);
+            }
+            core.setOutput('raw', raw);
+            core.setOutput('skipped', skipped ? 'true' : 'false');
+            core.setOutput('plan_url', planUrl);
+
+      - name: Commit backlog plan
+        if: steps.metadata.outputs.run == 'true' && steps.plan_result.outputs.skipped != 'true'
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: record Codex plan for project item ${{ steps.metadata.outputs.project_item_id }}"
+          file_pattern: backlog/backlog.yaml
+
+      - name: Move project item to Ready
+        if: steps.metadata.outputs.run == 'true' && steps.plan_result.outputs.skipped != 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PROJECTS_WORKFLOW_TOKEN != '' && secrets.PROJECTS_WORKFLOW_TOKEN || secrets.GITHUB_TOKEN }}
+          script: |
+            const projectId = '${{ steps.metadata.outputs.project_id }}';
+            const itemId = '${{ steps.metadata.outputs.project_item_node_id }}';
+            const fieldId = '${{ steps.metadata.outputs.status_field_id }}';
+            const optionId = '${{ steps.metadata.outputs.ready_option_id }}';
+
+            if (!projectId || !itemId || !fieldId || !optionId) {
+              core.setFailed('Missing identifiers required to move the project item to Ready.');
+              return;
+            }
+
+            await github.graphql(
+              `mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                updateProjectV2ItemFieldValue(
+                  input: {
+                    projectId: $projectId,
+                    itemId: $itemId,
+                    fieldId: $fieldId,
+                    value: { singleSelectOptionId: $optionId }
+                  }
+                ) {
+                  projectV2Item { id }
+                }
+              }`,
+              {
+                projectId,
+                itemId,
+                fieldId,
+                optionId,
+              },
+            );
+
+            core.info(`Moved project item ${itemId} to Ready.`);
+
+      - name: Clean up temporary files
+        if: steps.metadata.outputs.run == 'true'
+        run: |
+          rm -f backlog/context.json backlog/plan-result.json

--- a/backlog/backlog.yaml
+++ b/backlog/backlog.yaml
@@ -1,16 +1,1 @@
-# vTOC backlog template
-#
-# Duplicate the object under `items` for each backlog entry. Keep the list
-# sorted by `id` and prefer stable identifiers such as "BL-###".
-items:
-  - id: "BL-000"
-    title: "Short, action-oriented title"
-    status: proposed
-    summary: |
-      One or two paragraphs describing the change, the problem it solves,
-      and any critical acceptance criteria.
-    project_item_id: null
-    codex_plan_url: null
-    codex_run_ids: []
-    last_updated_by: "github:username"
-    metadata: {}
+items: []

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -79,8 +79,12 @@ When editing existing items:
 Codex and GitHub workflows will mutate the backlog with the following rules:
 
 - **Codex plan generation**: When a Codex plan is created from a backlog item,
-the automation writes the plan URL to `codex_plan_url`, appends the run identifier
-to `codex_run_ids`, and sets `last_updated_by` to `codex`.
+- the automation writes the plan URL to `codex_plan_url`, records a list of
+  generated tasks in `codex_plan_tasks`, appends the run identifier to
+  `codex_run_ids`, captures a timestamp in `codex_plan_generated_at`, and sets
+  `last_updated_by` to `codex`. Historical plans are appended to the
+  `plan_history` array with their generated timestamps so the team can audit
+  changes over time.
 - **GitHub Project sync**: A scheduled workflow syncs `project_item_id` with the
 canonical GitHub Project board. Items missing from the board remain `null`.
 - **Status enforcement**: Automations only advance states forward along the

--- a/scripts/automation/backlog_plan.py
+++ b/scripts/automation/backlog_plan.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Generate a Codex plan for a backlog entry and persist it to backlog/backlog.yaml."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Tuple
+
+try:
+    import yaml
+except ImportError as exc:  # pragma: no cover - dependency resolution handled by workflow
+    raise SystemExit("PyYAML must be installed to use backlog_plan.py") from exc
+
+
+ISO_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+ID_PREFIX = "BL-"
+ID_PADDING = 3
+
+
+class BacklogPlanError(Exception):
+    """Raised when the backlog registry has an unexpected structure."""
+
+
+@dataclass
+class PlanResult:
+    project_item_id: str
+    skipped: bool
+    plan_url: str | None = None
+    tasks: List[Dict[str, Any]] | None = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {
+            "project_item_id": self.project_item_id,
+            "skipped": self.skipped,
+        }
+        if self.plan_url is not None:
+            data["plan_url"] = self.plan_url
+        if self.tasks is not None:
+            data["tasks"] = self.tasks
+        return data
+
+
+def _load_json(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _load_backlog(path: Path) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
+    if not path.exists():
+        return {"items": []}, []
+
+    with path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+
+    if not isinstance(data, dict):
+        raise BacklogPlanError(f"Backlog file {path} must contain a mapping at the top level.")
+
+    items = data.get("items", [])
+    if items is None:
+        items = []
+    if not isinstance(items, list):
+        raise BacklogPlanError("The 'items' key in the backlog file must map to a list of entries.")
+
+    return data, list(items)
+
+
+def _normalize_multiline(value: str | None) -> str:
+    if not value:
+        return ""
+    lines = [line.rstrip() for line in value.splitlines()]
+    normalized = "\n".join(lines).strip()
+    return normalized
+
+
+def _generate_entry_id(items: Iterable[Dict[str, Any]]) -> str:
+    max_id = 0
+    for entry in items:
+        entry_id = entry.get("id")
+        if not isinstance(entry_id, str) or not entry_id.startswith(ID_PREFIX):
+            continue
+        suffix = entry_id[len(ID_PREFIX) :]
+        try:
+            numeric = int(suffix)
+        except ValueError:
+            continue
+        max_id = max(max_id, numeric)
+    return f"{ID_PREFIX}{max_id + 1:0{ID_PADDING}d}"
+
+
+def _item_sort_key(entry: Dict[str, Any]) -> Tuple[int, str]:
+    entry_id = entry.get("id")
+    if isinstance(entry_id, str) and entry_id.startswith(ID_PREFIX):
+        suffix = entry_id[len(ID_PREFIX) :]
+        try:
+            return int(suffix), entry_id
+        except ValueError:
+            pass
+    return (sys.maxsize, str(entry_id))
+
+
+def _ensure_entry(
+    items: List[Dict[str, Any]],
+    project_item_id: str,
+    context: Dict[str, Any],
+) -> Dict[str, Any]:
+    for entry in items:
+        if str(entry.get("project_item_id")) == project_item_id:
+            return entry
+
+    content = context.get("content") or {}
+    title = _normalize_multiline(content.get("title")) or f"Project item {project_item_id}"
+    summary = _normalize_multiline(content.get("body"))
+    if not summary:
+        summary = (
+            "Automatically generated from GitHub Projects item. Update this summary "
+            "with additional acceptance criteria."
+        )
+
+    new_entry = {
+        "id": _generate_entry_id(items),
+        "title": title,
+        "status": "proposed",
+        "summary": summary,
+        "project_item_id": project_item_id,
+        "codex_plan_url": None,
+        "codex_run_ids": [],
+        "last_updated_by": "codex",
+        "metadata": {
+            "project": context.get("project"),
+            "field_values": context.get("field_values"),
+            "content_url": content.get("url"),
+            "content_type": content.get("type"),
+        },
+    }
+    items.append(new_entry)
+    return new_entry
+
+
+def _normalise_tasks(raw_tasks: Any) -> List[Dict[str, Any]]:
+    if not raw_tasks:
+        return []
+
+    if isinstance(raw_tasks, list):
+        tasks: List[Dict[str, Any]] = []
+        for item in raw_tasks:
+            if isinstance(item, dict):
+                tasks.append(dict(item))
+            else:
+                tasks.append({"value": item})
+        return tasks
+
+    if isinstance(raw_tasks, dict):
+        return [dict(raw_tasks)]
+
+    return [{"value": raw_tasks}]
+
+
+def _detect_plan_fields(plan_data: Dict[str, Any]) -> Dict[str, Any]:
+    plan_url = (
+        plan_data.get("plan_url")
+        or plan_data.get("planUrl")
+        or plan_data.get("url")
+        or plan_data.get("plan", {}).get("url")
+    )
+
+    tasks = (
+        plan_data.get("tasks")
+        or plan_data.get("plan", {}).get("tasks")
+        or plan_data.get("task_ids")
+        or plan_data.get("taskIds")
+    )
+
+    if plan_url is None:
+        raise BacklogPlanError("Codex planning command did not return a plan URL.")
+
+    normalised_tasks = _normalise_tasks(tasks)
+    return {"plan_url": str(plan_url), "tasks": normalised_tasks}
+
+
+def _run_planning_command(command: str, context: Dict[str, Any]) -> Dict[str, Any]:
+    args = shlex.split(command)
+    try:
+        completed = subprocess.run(
+            args,
+            input=json.dumps(context).encode("utf-8"),
+            capture_output=True,
+            check=True,
+        )
+    except FileNotFoundError as exc:
+        raise BacklogPlanError(f"Planning command not found: {args[0]}") from exc
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr.decode("utf-8", errors="replace")
+        stdout = exc.stdout.decode("utf-8", errors="replace")
+        message = (
+            "Codex planning command failed with exit code "
+            f"{exc.returncode}.\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+        )
+        raise BacklogPlanError(message) from exc
+
+    stdout = completed.stdout.decode("utf-8", errors="replace").strip()
+    if not stdout:
+        raise BacklogPlanError("Codex planning command did not produce any output.")
+
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise BacklogPlanError("Codex planning command did not return valid JSON output.") from exc
+
+
+def _update_entry(entry: Dict[str, Any], context: Dict[str, Any], plan: Dict[str, Any]) -> None:
+    entry["project_item_id"] = context.get("project_item_id") or context.get("project_item_node_id")
+    entry["status"] = entry.get("status") or "proposed"
+    entry["codex_plan_url"] = plan["plan_url"]
+    entry["codex_plan_tasks"] = plan["tasks"]
+    entry.setdefault("metadata", {})
+    metadata = entry["metadata"]
+    if isinstance(metadata, dict):
+        metadata.setdefault("project", context.get("project"))
+        metadata["field_values"] = context.get("field_values")
+        content = context.get("content") or {}
+        if isinstance(content, dict):
+            metadata["content_url"] = content.get("url")
+            metadata["content_type"] = content.get("type")
+            metadata["content_number"] = content.get("number")
+    entry.setdefault("plan_history", [])
+    generated_at = datetime.now(timezone.utc).strftime(ISO_FORMAT)
+    if isinstance(entry["plan_history"], list):
+        entry["plan_history"].append(
+            {
+                "plan_url": plan["plan_url"],
+                "tasks": plan["tasks"],
+                "generated_at": generated_at,
+            }
+        )
+    entry["last_updated_by"] = "codex"
+    entry["codex_plan_generated_at"] = generated_at
+
+
+def _write_backlog(path: Path, data: Dict[str, Any]) -> None:
+    items = data.get("items", [])
+    if isinstance(items, list):
+        items.sort(key=_item_sort_key)
+        data["items"] = items
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(data, handle, sort_keys=False, allow_unicode=True)
+
+
+def parse_args(argv: List[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--context", required=True, help="Path to the backlog context JSON file.")
+    parser.add_argument(
+        "--backlog-file",
+        default="backlog/backlog.yaml",
+        help="Path to the backlog YAML file to update.",
+    )
+    parser.add_argument(
+        "--command",
+        default=None,
+        help=(
+            "Planning command to execute. Defaults to the CODEX_PLANNING_COMMAND environment "
+            "variable or 'codex cloud tasks plan --format json'."
+        ),
+    )
+    parser.add_argument(
+        "--skip-if-exists",
+        action="store_true",
+        help="Skip planning when the backlog entry already contains a plan URL.",
+    )
+    parser.add_argument(
+        "--result",
+        default=None,
+        help="Optional path to write the planning result JSON.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: List[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+
+    context_path = Path(args.context)
+    backlog_path = Path(args.backlog_file)
+
+    context = _load_json(context_path)
+    raw_id = context.get("project_item_id") or context.get("project_item_node_id")
+    if not raw_id:
+        raise BacklogPlanError(
+            "Context JSON must include a project_item_id or project_item_node_id."
+        )
+    project_item_id = str(raw_id)
+
+    data, items = _load_backlog(backlog_path)
+    entry = _ensure_entry(items, project_item_id, context)
+
+    if args.skip_if_exists and entry.get("codex_plan_url"):
+        result = PlanResult(project_item_id=project_item_id, skipped=True)
+    else:
+        command = (
+            args.command
+            or os.environ.get("CODEX_PLANNING_COMMAND")
+            or "codex cloud tasks plan --format json"
+        )
+        plan_output = _run_planning_command(command, context)
+        plan = _detect_plan_fields(plan_output)
+        _update_entry(entry, context, plan)
+        data["items"] = items
+        _write_backlog(backlog_path, data)
+        result = PlanResult(
+            project_item_id=project_item_id,
+            skipped=False,
+            plan_url=plan["plan_url"],
+            tasks=plan["tasks"],
+        )
+
+    if args.result:
+        result_path = Path(args.result)
+        with result_path.open("w", encoding="utf-8") as handle:
+            json.dump(result.to_dict(), handle)
+
+    json.dump(result.to_dict(), sys.stdout)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a Python helper that runs Codex planning, records plan metadata, and appends plan history inside `backlog/backlog.yaml`
- introduce a Projects v2 workflow that gathers item context, installs the Codex CLI, commits generated plans, and moves items to Ready
- initialize the backlog registry as an empty list and document the new Codex plan metadata fields

## Testing
- python -m compileall scripts/automation/backlog_plan.py

------
https://chatgpt.com/codex/tasks/task_e_68f13fd311c48323bdcd11e5e163c6c6