### PR TITLE
Add base station telemetry infrastructure models

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -34,6 +34,42 @@ class StationRead(StationBase):
     updated_at: datetime
 
 
+class BaseStationBase(BaseModel):
+    slug: str
+    name: str
+    description: Optional[str] = None
+    status: str = "active"
+    latitude: Optional[float] = None
+    longitude: Optional[float] = None
+    altitude_m: Optional[float] = None
+    metadata: Optional[dict[str, Any]] = None
+    station_id: Optional[int] = None
+
+
+class BaseStationCreate(BaseStationBase):
+    station_id: int
+
+
+class BaseStationUpdate(BaseModel):
+    slug: Optional[str] = None
+    name: Optional[str] = None
+    description: Optional[str] = None
+    status: Optional[str] = None
+    latitude: Optional[float] = None
+    longitude: Optional[float] = None
+    altitude_m: Optional[float] = None
+    metadata: Optional[dict[str, Any]] = None
+    station_id: Optional[int] = None
+
+
+class BaseStationRead(BaseStationBase):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+
 class TelemetrySourceBase(BaseModel):
     name: str
     slug: str
@@ -67,6 +103,52 @@ class TelemetrySourceRead(TelemetrySourceBase):
     last_ingested_at: Optional[datetime] = None
     created_at: datetime
     updated_at: datetime
+    station: Optional[StationRead] = None
+
+
+class DeviceBase(BaseModel):
+    slug: str
+    name: str
+    device_type: str
+    base_station_id: Optional[int] = None
+    station_id: Optional[int] = None
+    manufacturer: Optional[str] = None
+    model: Optional[str] = None
+    serial_number: Optional[str] = None
+    firmware_version: Optional[str] = None
+    is_active: bool = True
+    last_seen_at: Optional[datetime] = None
+    configuration: Optional[dict[str, Any]] = None
+    metadata: Optional[dict[str, Any]] = None
+
+
+class DeviceCreate(DeviceBase):
+    pass
+
+
+class DeviceUpdate(BaseModel):
+    slug: Optional[str] = None
+    name: Optional[str] = None
+    device_type: Optional[str] = None
+    base_station_id: Optional[int] = None
+    station_id: Optional[int] = None
+    manufacturer: Optional[str] = None
+    model: Optional[str] = None
+    serial_number: Optional[str] = None
+    firmware_version: Optional[str] = None
+    is_active: Optional[bool] = None
+    last_seen_at: Optional[datetime] = None
+    configuration: Optional[dict[str, Any]] = None
+    metadata: Optional[dict[str, Any]] = None
+
+
+class DeviceRead(DeviceBase):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    created_at: datetime
+    updated_at: datetime
+    base_station: Optional[BaseStationRead] = None
     station: Optional[StationRead] = None
 
 
@@ -108,9 +190,141 @@ class TelemetryEventRead(TelemetryEventBase):
     received_at: datetime
 
 
+class RfStreamBase(BaseModel):
+    slug: str
+    name: str
+    device_id: int
+    source_id: Optional[int] = None
+    description: Optional[str] = None
+    center_frequency_hz: Optional[int] = None
+    bandwidth_hz: Optional[int] = None
+    sample_rate: Optional[int] = None
+    modulation: Optional[str] = None
+    gain: Optional[float] = None
+    is_active: bool = True
+    configuration: Optional[dict[str, Any]] = None
+
+
+class RfStreamCreate(RfStreamBase):
+    pass
+
+
+class RfStreamUpdate(BaseModel):
+    slug: Optional[str] = None
+    name: Optional[str] = None
+    device_id: Optional[int] = None
+    source_id: Optional[int] = None
+    description: Optional[str] = None
+    center_frequency_hz: Optional[int] = None
+    bandwidth_hz: Optional[int] = None
+    sample_rate: Optional[int] = None
+    modulation: Optional[str] = None
+    gain: Optional[float] = None
+    is_active: Optional[bool] = None
+    configuration: Optional[dict[str, Any]] = None
+
+
+class RfStreamRead(RfStreamBase):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+
 class TelemetryEventWithSource(TelemetryEventRead):
     source: TelemetrySourceRead
     station: Optional[StationRead] = None
+
+
+class OverlayBase(BaseModel):
+    slug: str
+    name: str
+    station_id: int
+    overlay_type: str
+    description: Optional[str] = None
+    configuration: Optional[dict[str, Any]] = None
+    is_active: bool = True
+
+
+class OverlayCreate(OverlayBase):
+    pass
+
+
+class OverlayUpdate(BaseModel):
+    slug: Optional[str] = None
+    name: Optional[str] = None
+    station_id: Optional[int] = None
+    overlay_type: Optional[str] = None
+    description: Optional[str] = None
+    configuration: Optional[dict[str, Any]] = None
+    is_active: Optional[bool] = None
+
+
+class OverlayRead(OverlayBase):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+
+class TelemetryGpsFixBase(BaseModel):
+    source_id: Optional[int] = None
+    station_id: Optional[int] = None
+    device_id: Optional[int] = None
+    recorded_at: Optional[datetime] = None
+    latitude: Optional[float] = None
+    longitude: Optional[float] = None
+    altitude: Optional[float] = None
+    heading: Optional[float] = None
+    speed: Optional[float] = None
+    horizontal_accuracy: Optional[float] = None
+    vertical_accuracy: Optional[float] = None
+    raw_payload: Optional[dict[str, Any]] = None
+
+
+class TelemetryGpsFixCreate(TelemetryGpsFixBase):
+    pass
+
+
+class TelemetryGpsFixRead(TelemetryGpsFixBase):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    recorded_at: datetime
+    created_at: datetime
+
+
+class TelemetryAircraftPositionBase(BaseModel):
+    source_id: Optional[int] = None
+    station_id: Optional[int] = None
+    device_id: Optional[int] = None
+    icao_address: Optional[str] = None
+    callsign: Optional[str] = None
+    squawk: Optional[str] = None
+    latitude: Optional[float] = None
+    longitude: Optional[float] = None
+    altitude: Optional[float] = None
+    heading: Optional[float] = None
+    ground_speed: Optional[float] = None
+    vertical_rate: Optional[float] = None
+    position_time: Optional[datetime] = None
+    received_at: Optional[datetime] = None
+    raw_payload: Optional[dict[str, Any]] = None
+
+
+class TelemetryAircraftPositionCreate(TelemetryAircraftPositionBase):
+    pass
+
+
+class TelemetryAircraftPositionRead(TelemetryAircraftPositionBase):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    position_time: datetime
+    received_at: datetime
+    created_at: datetime
 
 
 class StationAssignmentBase(BaseModel):

--- a/database/migrations/20240310_0003_extended_telemetry.py
+++ b/database/migrations/20240310_0003_extended_telemetry.py
@@ -1,0 +1,270 @@
+"""Add infrastructure tables for base stations, devices, RF streams, overlays, and telemetry feeds."""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20240310_0003"
+down_revision = "20240210_0002"
+branch_labels = None
+depends_on = None
+
+
+BASE_STATION_STATUS_DEFAULT = "active"
+
+
+def upgrade() -> None:
+    op.execute("CREATE SCHEMA IF NOT EXISTS telemetry")
+
+    op.create_table(
+        "base_stations",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "station_id",
+            sa.Integer(),
+            sa.ForeignKey("stations.id", ondelete="CASCADE"),
+            nullable=True,
+            unique=True,
+        ),
+        sa.Column("slug", sa.String(length=100), nullable=False, unique=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("status", sa.String(length=50), nullable=False, server_default=BASE_STATION_STATUS_DEFAULT),
+        sa.Column("latitude", sa.Float(), nullable=True),
+        sa.Column("longitude", sa.Float(), nullable=True),
+        sa.Column("altitude_m", sa.Float(), nullable=True),
+        sa.Column("metadata", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_index("ix_base_stations_slug", "base_stations", ["slug"], unique=True)
+
+    op.create_table(
+        "devices",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "base_station_id",
+            sa.Integer(),
+            sa.ForeignKey("base_stations.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "station_id",
+            sa.Integer(),
+            sa.ForeignKey("stations.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("slug", sa.String(length=100), nullable=False, unique=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("device_type", sa.String(length=100), nullable=False),
+        sa.Column("manufacturer", sa.String(length=255), nullable=True),
+        sa.Column("model", sa.String(length=255), nullable=True),
+        sa.Column("serial_number", sa.String(length=255), nullable=True),
+        sa.Column("firmware_version", sa.String(length=100), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("last_seen_at", sa.DateTime(), nullable=True),
+        sa.Column("configuration", sa.JSON(), nullable=True),
+        sa.Column("metadata", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_index("ix_devices_slug", "devices", ["slug"], unique=True)
+    op.create_index("ix_devices_base_station_id", "devices", ["base_station_id"])
+    op.create_index("ix_devices_station_id", "devices", ["station_id"])
+
+    op.create_table(
+        "rf_streams",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "device_id",
+            sa.Integer(),
+            sa.ForeignKey("devices.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "source_id",
+            sa.Integer(),
+            sa.ForeignKey("telemetry_sources.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("slug", sa.String(length=100), nullable=False, unique=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("center_frequency_hz", sa.BigInteger(), nullable=True),
+        sa.Column("bandwidth_hz", sa.BigInteger(), nullable=True),
+        sa.Column("sample_rate", sa.BigInteger(), nullable=True),
+        sa.Column("modulation", sa.String(length=100), nullable=True),
+        sa.Column("gain", sa.Float(), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("configuration", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_index("ix_rf_streams_slug", "rf_streams", ["slug"], unique=True)
+    op.create_index("ix_rf_streams_device_id", "rf_streams", ["device_id"])
+    op.create_index("ix_rf_streams_source_id", "rf_streams", ["source_id"])
+
+    op.create_table(
+        "overlays",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "station_id",
+            sa.Integer(),
+            sa.ForeignKey("stations.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("slug", sa.String(length=100), nullable=False, unique=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("overlay_type", sa.String(length=100), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("configuration", sa.JSON(), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_index("ix_overlays_slug", "overlays", ["slug"], unique=True)
+    op.create_index("ix_overlays_station_id", "overlays", ["station_id"])
+
+    op.create_table(
+        "gps_fixes",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "source_id",
+            sa.Integer(),
+            sa.ForeignKey("telemetry_sources.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "station_id",
+            sa.Integer(),
+            sa.ForeignKey("stations.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "device_id",
+            sa.Integer(),
+            sa.ForeignKey("devices.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("recorded_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("latitude", sa.Float(), nullable=True),
+        sa.Column("longitude", sa.Float(), nullable=True),
+        sa.Column("altitude", sa.Float(), nullable=True),
+        sa.Column("heading", sa.Float(), nullable=True),
+        sa.Column("speed", sa.Float(), nullable=True),
+        sa.Column("horizontal_accuracy", sa.Float(), nullable=True),
+        sa.Column("vertical_accuracy", sa.Float(), nullable=True),
+        sa.Column("raw_payload", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        schema="telemetry",
+    )
+    op.create_index(
+        "ix_gps_fixes_recorded_at",
+        "gps_fixes",
+        ["recorded_at"],
+        schema="telemetry",
+    )
+    op.create_index(
+        "ix_gps_fixes_source_id",
+        "gps_fixes",
+        ["source_id"],
+        schema="telemetry",
+    )
+
+    op.create_table(
+        "aircraft_positions",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "source_id",
+            sa.Integer(),
+            sa.ForeignKey("telemetry_sources.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "station_id",
+            sa.Integer(),
+            sa.ForeignKey("stations.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "device_id",
+            sa.Integer(),
+            sa.ForeignKey("devices.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("icao_address", sa.String(length=6), nullable=True),
+        sa.Column("callsign", sa.String(length=16), nullable=True),
+        sa.Column("squawk", sa.String(length=8), nullable=True),
+        sa.Column("latitude", sa.Float(), nullable=True),
+        sa.Column("longitude", sa.Float(), nullable=True),
+        sa.Column("altitude", sa.Float(), nullable=True),
+        sa.Column("heading", sa.Float(), nullable=True),
+        sa.Column("ground_speed", sa.Float(), nullable=True),
+        sa.Column("vertical_rate", sa.Float(), nullable=True),
+        sa.Column("position_time", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("received_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("raw_payload", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        schema="telemetry",
+    )
+    op.create_index(
+        "ix_aircraft_positions_position_time",
+        "aircraft_positions",
+        ["position_time"],
+        schema="telemetry",
+    )
+    op.create_index(
+        "ix_aircraft_positions_source_id",
+        "aircraft_positions",
+        ["source_id"],
+        schema="telemetry",
+    )
+
+    connection = op.get_bind()
+    stations = list(connection.execute(sa.text("SELECT id, slug, name FROM stations")))
+    for station in stations:
+        connection.execute(
+            sa.text(
+                """
+                INSERT INTO base_stations (station_id, slug, name, description, status)
+                VALUES (:station_id, :slug, :name, '', :status)
+                ON CONFLICT (slug) DO NOTHING
+                """
+            ),
+            {
+                "station_id": station.id,
+                "slug": station.slug,
+                "name": station.name,
+                "status": BASE_STATION_STATUS_DEFAULT,
+            },
+        )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_aircraft_positions_source_id", table_name="aircraft_positions", schema="telemetry")
+    op.drop_index("ix_aircraft_positions_position_time", table_name="aircraft_positions", schema="telemetry")
+    op.drop_table("aircraft_positions", schema="telemetry")
+
+    op.drop_index("ix_gps_fixes_source_id", table_name="gps_fixes", schema="telemetry")
+    op.drop_index("ix_gps_fixes_recorded_at", table_name="gps_fixes", schema="telemetry")
+    op.drop_table("gps_fixes", schema="telemetry")
+
+    op.drop_index("ix_overlays_station_id", table_name="overlays")
+    op.drop_index("ix_overlays_slug", table_name="overlays")
+    op.drop_table("overlays")
+
+    op.drop_index("ix_rf_streams_source_id", table_name="rf_streams")
+    op.drop_index("ix_rf_streams_device_id", table_name="rf_streams")
+    op.drop_index("ix_rf_streams_slug", table_name="rf_streams")
+    op.drop_table("rf_streams")
+
+    op.drop_index("ix_devices_station_id", table_name="devices")
+    op.drop_index("ix_devices_base_station_id", table_name="devices")
+    op.drop_index("ix_devices_slug", table_name="devices")
+    op.drop_table("devices")
+
+    op.drop_index("ix_base_stations_slug", table_name="base_stations")
+    op.drop_table("base_stations")
+
+    op.execute("DROP SCHEMA IF EXISTS telemetry CASCADE")


### PR DESCRIPTION
## Summary
- add an Alembic revision that creates base station, device, RF stream, overlay, GPS fix, and aircraft position tables with legacy backfill
- extend SQLAlchemy models and Pydantic schemas to expose the new infrastructure entities and telemetry feeds
- update the Supabase repository with CRUD helpers for the new tables and telemetry data accessors

## Testing
- python -m compileall backend/app

------
https://chatgpt.com/codex/tasks/task_e_68f28fa4c2b08323ae6e4d6b8d9d2748