### PR TITLE
Add GPS ingest service scaffold

### DIFF
--- a/services/gps-ingest/Dockerfile
+++ b/services/gps-ingest/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY services/gps-ingest/pyproject.toml ./
+COPY services/gps-ingest/README.md ./
+RUN pip install --upgrade pip \
+    && pip install .
+
+COPY services/gps-ingest/gps_ingest ./gps_ingest
+
+ENTRYPOINT ["python", "-m", "gps_ingest"]

--- a/services/gps-ingest/README.md
+++ b/services/gps-ingest/README.md
@@ -1,0 +1,65 @@
+# GPS Ingest Service
+
+The GPS ingest service opens a serial connection to a GPS receiver, parses NMEA
+sentences, and forwards normalized position fixes to the vTOC backend API.
+
+## Configuration
+
+Configuration is provided via environment variables. The following variables are
+required:
+
+| Variable | Description |
+| --- | --- |
+| `GPS_SERIAL` | Serial device path (e.g. `/dev/ttyUSB0`). |
+| `GPS_BAUD` | Optional baud rate for the GPS receiver (defaults to `9600`). |
+| `GPS_API_URL` | Fully-qualified backend endpoint that accepts GPS fixes. |
+| `GPS_API_TOKEN` | Optional bearer token for authenticating with the backend. |
+
+Additional optional settings:
+
+| Variable | Description |
+| --- | --- |
+| `GPS_RECONNECT_INITIAL` | Initial delay (seconds) before retrying serial connections (default `1.0`). |
+| `GPS_RECONNECT_MAX_DELAY` | Maximum backoff delay (seconds) between retries (default `30.0`). |
+| `GPS_RECONNECT_MAX_ATTEMPTS` | Maximum number of connection attempts before raising (unlimited by default). |
+| `GPS_SERIAL_TIMEOUT` | Serial read timeout in seconds (default `1.0`). |
+
+## Running locally
+
+Install the service dependencies and execute the entrypoint:
+
+```bash
+pip install -e services/gps-ingest
+GPS_SERIAL=/dev/ttyUSB0 \
+GPS_API_URL=https://example.com/api/gps \
+python -m gps_ingest
+```
+
+The service will continuously read sentences from the serial device, parse
+position fixes, and POST JSON payloads to the configured API endpoint.
+
+## Testing
+
+Unit tests cover the NMEA parsing logic and serial connection retry behaviour.
+Run them with:
+
+```bash
+pytest services/gps-ingest/tests
+```
+
+## Docker
+
+A Dockerfile is provided for containerized deployments:
+
+```bash
+docker build -t vtoc-gps-ingest -f services/gps-ingest/Dockerfile .
+docker run --rm \
+  --device=/dev/ttyUSB0 \
+  -e GPS_SERIAL=/dev/ttyUSB0 \
+  -e GPS_API_URL=https://example.com/api/gps \
+  -e GPS_API_TOKEN=your-token \
+  vtoc-gps-ingest
+```
+
+Mount or pass the GPS serial device into the container using the `--device`
+flag when running on Linux hosts.

--- a/services/gps-ingest/gps_ingest/__init__.py
+++ b/services/gps-ingest/gps_ingest/__init__.py
@@ -1,0 +1,13 @@
+"""GPS ingestion service package."""
+
+from .config import Config, load_config
+from .parser import GPSFix, parse_nmea_sentence
+from .service import GPSIngestService
+
+__all__ = [
+    "Config",
+    "GPSFix",
+    "GPSIngestService",
+    "load_config",
+    "parse_nmea_sentence",
+]

--- a/services/gps-ingest/gps_ingest/__main__.py
+++ b/services/gps-ingest/gps_ingest/__main__.py
@@ -1,0 +1,19 @@
+"""Entrypoint for running the GPS ingestion service."""
+
+from __future__ import annotations
+
+import logging
+
+from .config import load_config
+from .service import GPSIngestService
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+    config = load_config()
+    service = GPSIngestService(config)
+    service.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/services/gps-ingest/gps_ingest/config.py
+++ b/services/gps-ingest/gps_ingest/config.py
@@ -1,0 +1,96 @@
+"""Configuration loading for the GPS ingestion service."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Mapping, Optional
+
+
+@dataclass(slots=True)
+class Config:
+    """Runtime configuration values for the GPS ingestion service."""
+
+    serial_port: str
+    baud_rate: int
+    api_url: str
+    api_token: Optional[str]
+    reconnect_initial: float = 1.0
+    reconnect_max_delay: float = 30.0
+    reconnect_max_attempts: Optional[int] = None
+    serial_timeout: float = 1.0
+
+    @property
+    def headers(self) -> dict[str, str]:
+        """Return default HTTP headers for publishing."""
+
+        headers = {"User-Agent": "gps-ingest/0.1"}
+        if self.api_token:
+            headers["Authorization"] = f"Bearer {self.api_token}"
+        return headers
+
+
+def _get_env(env: Mapping[str, str], key: str) -> str:
+    try:
+        value = env[key]
+    except KeyError as exc:
+        raise ValueError(f"Missing required environment variable: {key}") from exc
+    if not value:
+        raise ValueError(f"Environment variable {key} cannot be empty")
+    return value
+
+
+def load_config(env: Mapping[str, str] | None = None) -> Config:
+    """Load configuration from environment variables.
+
+    Parameters
+    ----------
+    env:
+        Mapping of environment variables. Defaults to :data:`os.environ`.
+
+    Returns
+    -------
+    Config
+        Populated configuration dataclass.
+
+    Raises
+    ------
+    ValueError
+        If any required configuration is missing or invalid.
+    """
+
+    env = env or os.environ
+
+    serial_port = _get_env(env, "GPS_SERIAL")
+
+    baud_raw = env.get("GPS_BAUD", "9600")
+    try:
+        baud_rate = int(baud_raw)
+    except ValueError as exc:
+        raise ValueError("GPS_BAUD must be an integer") from exc
+    if baud_rate <= 0:
+        raise ValueError("GPS_BAUD must be positive")
+
+    api_url = _get_env(env, "GPS_API_URL")
+    api_token = env.get("GPS_API_TOKEN") or None
+
+    reconnect_initial = float(env.get("GPS_RECONNECT_INITIAL", 1.0))
+    reconnect_max_delay = float(env.get("GPS_RECONNECT_MAX_DELAY", 30.0))
+    reconnect_max_attempts_raw = env.get("GPS_RECONNECT_MAX_ATTEMPTS")
+    reconnect_max_attempts = (
+        int(reconnect_max_attempts_raw)
+        if reconnect_max_attempts_raw not in (None, "")
+        else None
+    )
+    serial_timeout = float(env.get("GPS_SERIAL_TIMEOUT", 1.0))
+
+    return Config(
+        serial_port=serial_port,
+        baud_rate=baud_rate,
+        api_url=api_url,
+        api_token=api_token,
+        reconnect_initial=reconnect_initial,
+        reconnect_max_delay=reconnect_max_delay,
+        reconnect_max_attempts=reconnect_max_attempts,
+        serial_timeout=serial_timeout,
+    )

--- a/services/gps-ingest/gps_ingest/parser.py
+++ b/services/gps-ingest/gps_ingest/parser.py
@@ -1,0 +1,97 @@
+"""Parsing utilities for GPS NMEA sentences."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+import pynmea2
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class GPSFix:
+    """Normalized GPS fix information extracted from NMEA sentences."""
+
+    latitude: float
+    longitude: float
+    altitude_m: Optional[float] = None
+    speed_kmh: Optional[float] = None
+    timestamp: Optional[datetime] = None
+
+    def to_payload(self) -> dict[str, float | str]:
+        """Convert the fix into a JSON-serializable payload."""
+
+        payload: dict[str, float | str] = {
+            "latitude": self.latitude,
+            "longitude": self.longitude,
+        }
+        if self.altitude_m is not None:
+            payload["altitude_m"] = self.altitude_m
+        if self.speed_kmh is not None:
+            payload["speed_kmh"] = self.speed_kmh
+        if self.timestamp is not None:
+            payload["timestamp"] = self.timestamp.isoformat()
+        return payload
+
+
+def _coerce_float(value: object) -> Optional[float]:
+    if value in (None, ""):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _derive_timestamp(message: pynmea2.nmea.NMEASentence) -> Optional[datetime]:
+    datestamp = getattr(message, "datestamp", None)
+    timestamp = getattr(message, "timestamp", None)
+    if datestamp and timestamp:
+        return datetime.combine(datestamp, timestamp)
+    return None
+
+
+def parse_nmea_sentence(sentence: str) -> Optional[GPSFix]:
+    """Parse a raw NMEA sentence into a :class:`GPSFix` instance.
+
+    Returns ``None`` when the sentence cannot be parsed or does not contain
+    positional information.
+    """
+
+    sentence = sentence.strip()
+    if not sentence:
+        return None
+
+    try:
+        message = pynmea2.parse(sentence, check=True)
+    except (pynmea2.nmea.ParseError, pynmea2.nmea.ChecksumError, ValueError) as exc:
+        logger.debug("Failed to parse NMEA sentence %r: %s", sentence, exc)
+        return None
+
+    latitude = _coerce_float(getattr(message, "latitude", None))
+    longitude = _coerce_float(getattr(message, "longitude", None))
+    if latitude is None or longitude is None:
+        return None
+
+    altitude = _coerce_float(getattr(message, "altitude", None))
+
+    speed_knots = _coerce_float(
+        getattr(message, "spd_over_grnd", None)
+        or getattr(message, "speed", None)
+        or getattr(message, "spd_over_ground", None)
+    )
+    speed_kmh = speed_knots * 1.852 if speed_knots is not None else None
+
+    timestamp = _derive_timestamp(message)
+
+    return GPSFix(
+        latitude=latitude,
+        longitude=longitude,
+        altitude_m=altitude,
+        speed_kmh=speed_kmh,
+        timestamp=timestamp,
+    )

--- a/services/gps-ingest/gps_ingest/service.py
+++ b/services/gps-ingest/gps_ingest/service.py
@@ -1,0 +1,127 @@
+"""Runtime service loop for ingesting GPS data."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from contextlib import contextmanager
+from typing import Callable, Iterable
+
+import requests
+import serial
+
+from .config import Config
+from .parser import GPSFix, parse_nmea_sentence
+
+logger = logging.getLogger(__name__)
+
+SerialFactory = Callable[..., serial.Serial]
+SleepCallable = Callable[[float], None]
+
+
+def connect_serial_with_retry(
+    config: Config,
+    serial_factory: SerialFactory,
+    sleep: SleepCallable = time.sleep,
+) -> serial.Serial:
+    """Attempt to connect to the serial device with exponential backoff."""
+
+    attempt = 0
+    delay = max(config.reconnect_initial, 0)
+    while True:
+        try:
+            logger.info(
+                "Opening GPS serial connection on %s @ %s baud",
+                config.serial_port,
+                config.baud_rate,
+            )
+            connection = serial_factory(
+                port=config.serial_port,
+                baudrate=config.baud_rate,
+                timeout=config.serial_timeout,
+            )
+            logger.info("GPS serial connection established")
+            return connection
+        except serial.SerialException as exc:
+            attempt += 1
+            logger.warning("GPS serial connection failed (attempt %s): %s", attempt, exc)
+            if config.reconnect_max_attempts and attempt >= config.reconnect_max_attempts:
+                raise
+            sleep(delay)
+            delay = min(max(delay * 2, 0.1), config.reconnect_max_delay)
+
+
+class GPSIngestService:
+    """High-level orchestration for streaming GPS fixes to the backend API."""
+
+    def __init__(
+        self,
+        config: Config,
+        serial_factory: SerialFactory = serial.Serial,
+        session: requests.Session | None = None,
+        sleep: SleepCallable = time.sleep,
+    ) -> None:
+        self.config = config
+        self.serial_factory = serial_factory
+        self.session = session or requests.Session()
+        self.sleep = sleep
+
+    @contextmanager
+    def _serial_connection(self) -> Iterable[serial.Serial]:
+        connection = connect_serial_with_retry(self.config, self.serial_factory, self.sleep)
+        try:
+            yield connection
+        finally:
+            try:
+                connection.close()
+            except serial.SerialException:
+                logger.debug("Serial connection already closed")
+
+    def publish_fix(self, fix: GPSFix) -> None:
+        payload = fix.to_payload()
+        logger.debug("Publishing GPS fix: %s", json.dumps(payload))
+        response = self.session.post(
+            self.config.api_url,
+            json=payload,
+            headers=self.config.headers,
+            timeout=10,
+        )
+        response.raise_for_status()
+
+    def run(self) -> None:
+        """Run the ingestion loop until interrupted."""
+
+        logger.info("Starting GPS ingestion service")
+        try:
+            while True:
+                try:
+                    with self._serial_connection() as connection:
+                        self._stream(connection)
+                except serial.SerialException as exc:
+                    logger.warning("Serial connection lost: %s", exc)
+                    self.sleep(self.config.reconnect_initial)
+        except KeyboardInterrupt:
+            logger.info("GPS ingestion interrupted; shutting down")
+        finally:
+            self.session.close()
+
+    def _stream(self, connection: serial.Serial) -> None:
+        while True:
+            raw = connection.readline()
+            if not raw:
+                continue
+            try:
+                sentence = raw.decode("ascii", errors="ignore").strip()
+            except UnicodeDecodeError:
+                logger.debug("Received undecodable bytes from GPS receiver")
+                continue
+            fix = parse_nmea_sentence(sentence)
+            if not fix:
+                continue
+            try:
+                self.publish_fix(fix)
+            except requests.RequestException as exc:
+                logger.error("Failed to publish GPS fix: %s", exc)
+                self.sleep(self.config.reconnect_initial)
+                break

--- a/services/gps-ingest/pyproject.toml
+++ b/services/gps-ingest/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=65", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gps-ingest"
+version = "0.1.0"
+description = "Serial GPS ingestion service for vTOC"
+authors = [{ name = "vTOC" }]
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.10"
+dependencies = [
+  "pyserial>=3.5",
+  "pynmea2>=1.19.0",
+  "requests>=2.31.0",
+]
+
+[project.scripts]
+gps-ingest = "gps_ingest.__main__:main"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"

--- a/services/gps-ingest/tests/test_parser.py
+++ b/services/gps-ingest/tests/test_parser.py
@@ -1,0 +1,35 @@
+import pytest
+
+from gps_ingest.parser import GPSFix, parse_nmea_sentence
+
+
+def test_parse_rmc_sentence_returns_fix():
+    sentence = "$GPRMC,123519,A,4807.038,N,01131.000,E,022.4,084.4,230394,003.1,W*6A"
+
+    fix = parse_nmea_sentence(sentence)
+
+    assert isinstance(fix, GPSFix)
+    assert pytest.approx(fix.latitude, rel=1e-3) == 48.1173
+    assert pytest.approx(fix.longitude, rel=1e-3) == 11.5166667
+    assert fix.speed_kmh is not None
+    assert fix.speed_kmh == pytest.approx(22.4 * 1.852)
+
+
+def test_parse_gga_sentence_includes_altitude():
+    sentence = "$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*47"
+
+    fix = parse_nmea_sentence(sentence)
+
+    assert fix is not None
+    assert pytest.approx(fix.altitude_m, rel=1e-3) == 545.4
+
+
+def test_parse_invalid_sentence_returns_none():
+    assert parse_nmea_sentence("$GPRMC,invalid*") is None
+    assert parse_nmea_sentence("") is None
+
+
+def test_parse_sentence_without_position_returns_none():
+    # VTG sentences contain velocity but no lat/long.
+    sentence = "$GPVTG,054.7,T,034.4,M,005.5,N,010.2,K*48"
+    assert parse_nmea_sentence(sentence) is None

--- a/services/gps-ingest/tests/test_retry.py
+++ b/services/gps-ingest/tests/test_retry.py
@@ -1,0 +1,63 @@
+import itertools
+
+import pytest
+import serial
+
+from gps_ingest.config import Config
+from gps_ingest.service import connect_serial_with_retry
+
+
+class DummySerial:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    def close(self):
+        pass
+
+
+def test_connect_serial_with_retry_eventually_succeeds(monkeypatch):
+    attempts = itertools.count()
+
+    def factory(**kwargs):
+        if next(attempts) < 2:
+            raise serial.SerialException("boom")
+        return DummySerial(**kwargs)
+
+    sleep_calls = []
+
+    def fake_sleep(delay):
+        sleep_calls.append(delay)
+
+    config = Config(
+        serial_port="/dev/ttyUSB0",
+        baud_rate=4800,
+        api_url="https://example.com",
+        api_token=None,
+        reconnect_initial=0.1,
+        reconnect_max_delay=0.5,
+        reconnect_max_attempts=5,
+    )
+
+    conn = connect_serial_with_retry(config, factory, fake_sleep)
+
+    assert isinstance(conn, DummySerial)
+    assert sleep_calls == [0.1, 0.2]
+
+
+def test_connect_serial_with_retry_respects_max_attempts():
+    def factory(**kwargs):
+        raise serial.SerialException("nope")
+
+    config = Config(
+        serial_port="/dev/ttyUSB0",
+        baud_rate=4800,
+        api_url="https://example.com",
+        api_token=None,
+        reconnect_initial=0.01,
+        reconnect_max_delay=0.02,
+        reconnect_max_attempts=3,
+    )
+
+    with pytest.raises(serial.SerialException):
+        connect_serial_with_retry(config, factory, lambda _: None)


### PR DESCRIPTION
## Summary
- add a gps-ingest service package with configuration loading, serial connection management, and publishing logic
- provide packaging metadata, Dockerfile, and documentation for running the service
- cover NMEA parsing and serial reconnection logic with unit tests

## Testing
- PYTHONPATH=services/gps-ingest pytest services/gps-ingest/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68f28facf52083238dca5ce401b6abf6