### PR TITLE
Add H4M bridge service for log ingestion

### DIFF
--- a/services/h4m-bridge/README.md
+++ b/services/h4m-bridge/README.md
@@ -1,0 +1,68 @@
+# H4M Bridge Service
+
+The H4M bridge scans mounted H4M storage for IQ capture files and decoded log
+exports, extracts basic metadata, and forwards structured events to the vTOC
+backend. The service is implemented in Python and designed to run on a worker
+with `/mnt/h4m` mounted locally.
+
+## Supported formats
+
+The bridge recognises two high-level families of log files:
+
+| Type     | Extensions                                    | Metadata extraction |
+|----------|------------------------------------------------|---------------------|
+| IQ       | `.iq`, `.cfile`, `.iq.tar`, `.iq.gz`           | Size, modified time, first 32 bytes preview |
+| Decoded  | `.json`, `.ndjson`, `.log`, `.txt`             | Size, modified time, first line (JSON parsed when available) |
+
+Additional extensions can be added in `h4m_bridge/scanner.py`.
+
+## Usage
+
+```bash
+python -m h4m_bridge.cli \
+  --storage /mnt/h4m \
+  --backend-url https://backend.example.com/api/h4m/logs \
+  --dedup-state /var/lib/h4m-bridge/state.json
+```
+
+### Environment variables
+
+The CLI accepts environment overrides for the most common parameters:
+
+- `H4M_STORAGE` – storage root (defaults to `/mnt/h4m`).
+- `H4M_BACKEND_URL` – backend endpoint for posting log events.
+- `H4M_DEDUP_STATE` – location of the deduplication state file.
+
+### Dry run mode
+
+Pass `--dry-run` to disable HTTP requests and deduplication state updates. The
+service still scans files and logs the summary of work that *would* be
+performed. This is useful for verifying configuration prior to enabling
+imports.
+
+## Deduplication
+
+Imported files are tracked in a JSON state file keyed by the absolute path and
+file signature (size + modified timestamp). Subsequent runs skip unchanged
+files to avoid sending duplicate events. The deduplication logic lives in
+`h4m_bridge/dedup.py`.
+
+## Logging & summaries
+
+The bridge logs each discovered file at debug level and prints a structured
+summary at the end of every run. Summary data includes total processed files,
+number imported, duplicates skipped, failures, and a per-type breakdown.
+
+## Development
+
+Install dependencies (only standard library is required) and run tests with
+pytest:
+
+```bash
+pip install -r requirements.txt  # optional, standard library only
+pytest services/h4m-bridge/tests
+```
+
+Fixture-based tests provide coverage for scanning, deduplication, and dry-run
+behaviour. Test fixtures live under `services/h4m-bridge/tests/fixtures`.
+

--- a/services/h4m-bridge/h4m_bridge/__init__.py
+++ b/services/h4m-bridge/h4m_bridge/__init__.py
@@ -1,0 +1,14 @@
+"""H4M Bridge package."""
+
+from .bridge import BridgeImporter
+from .scanner import LogRecord, LogScanner
+from .dedup import FileDeduplicator
+from .client import BridgeClient
+
+__all__ = [
+    "BridgeImporter",
+    "LogRecord",
+    "LogScanner",
+    "FileDeduplicator",
+    "BridgeClient",
+]

--- a/services/h4m-bridge/h4m_bridge/bridge.py
+++ b/services/h4m-bridge/h4m_bridge/bridge.py
@@ -1,0 +1,82 @@
+"""Bridge orchestration for importing logs."""
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Dict
+
+from .client import BridgeClient
+from .dedup import FileDeduplicator
+from .scanner import LogScanner
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class ImportSummary:
+    processed: int = 0
+    imported: int = 0
+    duplicates: int = 0
+    failed: int = 0
+    by_type: Counter = field(default_factory=Counter)
+
+    def as_dict(self) -> Dict[str, object]:
+        return {
+            "processed": self.processed,
+            "imported": self.imported,
+            "duplicates": self.duplicates,
+            "failed": self.failed,
+            "by_type": dict(self.by_type),
+        }
+
+
+@dataclass
+class BridgeImporter:
+    storage_path: str
+    backend_url: str
+    dedup_path: str
+    dry_run: bool = False
+
+    def run(self) -> ImportSummary:
+        scanner = LogScanner(self.storage_path)
+        deduplicator = FileDeduplicator(self.dedup_path)
+        client = BridgeClient(self.backend_url)
+        summary = ImportSummary()
+        pending_records = []
+
+        for record in scanner.scan():
+            summary.processed += 1
+            if deduplicator.is_duplicate(record):
+                summary.duplicates += 1
+                continue
+
+            payload = {
+                "path": record.path,
+                "log_type": record.log_type,
+                "size": record.size,
+                "modified_at": record.modified_at.isoformat(),
+                "metadata": record.metadata,
+            }
+
+            try:
+                if not self.dry_run:
+                    client.post_event(payload)
+                else:
+                    LOGGER.info("Dry run: skipping backend post", extra={"path": record.path})
+                summary.imported += 1
+                summary.by_type[record.log_type] += 1
+                pending_records.append(record)
+            except Exception:
+                summary.failed += 1
+                LOGGER.exception("Failed to import log", extra={"path": record.path})
+
+        if not self.dry_run:
+            deduplicator.mark_many(pending_records)
+            deduplicator.flush()
+        else:
+            LOGGER.info("Dry run complete; no files marked as imported")
+
+        LOGGER.info("Import summary", extra=summary.as_dict())
+        return summary
+

--- a/services/h4m-bridge/h4m_bridge/cli.py
+++ b/services/h4m-bridge/h4m_bridge/cli.py
@@ -1,0 +1,71 @@
+"""Command-line interface for the H4M bridge."""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+from pathlib import Path
+
+from .bridge import BridgeImporter
+
+LOGGER = logging.getLogger(__name__)
+
+
+def configure_logging(verbose: bool = False) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s %(name)s :: %(message)s",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="H4M bridge log importer")
+    parser.add_argument(
+        "--storage",
+        default=os.environ.get("H4M_STORAGE", "/mnt/h4m"),
+        help="Path to mounted H4M storage",
+    )
+    parser.add_argument(
+        "--backend-url",
+        default=os.environ.get("H4M_BACKEND_URL", "http://localhost:8000/api/h4m/logs"),
+        help="Backend endpoint for posting log events",
+    )
+    parser.add_argument(
+        "--dedup-state",
+        default=os.environ.get("H4M_DEDUP_STATE", Path.home() / ".h4m_bridge_state.json"),
+        help="Location for deduplication state",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Scan and summarise without posting to backend",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable debug logging",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    configure_logging(args.verbose)
+
+    importer = BridgeImporter(
+        storage_path=args.storage,
+        backend_url=args.backend_url,
+        dedup_path=str(args.dedup_state),
+        dry_run=args.dry_run,
+    )
+
+    summary = importer.run()
+    LOGGER.info("Completed import", extra=summary.as_dict())
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+

--- a/services/h4m-bridge/h4m_bridge/client.py
+++ b/services/h4m-bridge/h4m_bridge/client.py
@@ -1,0 +1,40 @@
+"""HTTP client for posting bridge events."""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Dict
+from urllib import request, error
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class BridgeClient:
+    """Simple HTTP client that posts JSON payloads to the backend."""
+
+    backend_url: str
+    timeout: float = 10.0
+
+    def post_event(self, payload: Dict[str, object]) -> None:
+        data = json.dumps(payload).encode("utf-8")
+        req = request.Request(
+            self.backend_url,
+            data=data,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with request.urlopen(req, timeout=self.timeout) as response:
+                response.read()  # ensure request completes
+        except error.HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="ignore") if hasattr(exc, "read") else ""
+            LOGGER.error(
+                "Backend rejected log event", extra={"status": exc.code, "reason": exc.reason, "body": body}
+            )
+            raise
+        except error.URLError as exc:
+            LOGGER.error("Failed to reach backend", extra={"reason": str(exc)})
+            raise
+

--- a/services/h4m-bridge/h4m_bridge/dedup.py
+++ b/services/h4m-bridge/h4m_bridge/dedup.py
@@ -1,0 +1,74 @@
+"""Deduplication helpers for the H4M bridge."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+import logging
+from pathlib import Path
+from typing import Dict, Iterable
+
+from .scanner import LogRecord
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class FileDeduplicator:
+    """Track which log files have already been imported.
+
+    The deduplicator stores metadata on disk so subsequent runs do not
+    reprocess the same files. Each record is stored by the file's absolute
+    path with a signature comprised of the file size and last modification
+    timestamp. This provides a good balance between accuracy and performance
+    without requiring checksums for large IQ capture files.
+    """
+
+    state_path: Path
+    _state: Dict[str, str] = field(default_factory=dict, init=False)
+    _dirty: bool = field(default=False, init=False)
+
+    def __post_init__(self) -> None:
+        self.state_path = Path(self.state_path)
+        if self.state_path.exists():
+            try:
+                self._state = json.loads(self.state_path.read_text())
+            except json.JSONDecodeError:
+                LOGGER.warning("Deduplicator state file is corrupt; starting fresh", extra={"state_path": str(self.state_path)})
+                self._state = {}
+        else:
+            if not self.state_path.parent.exists():
+                self.state_path.parent.mkdir(parents=True, exist_ok=True)
+            self._state = {}
+
+    def __enter__(self) -> "FileDeduplicator":
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        self.flush()
+
+    def flush(self) -> None:
+        if self._dirty:
+            self.state_path.write_text(json.dumps(self._state, indent=2, sort_keys=True))
+            self._dirty = False
+
+    def is_duplicate(self, record: LogRecord) -> bool:
+        signature = record.signature
+        stored = self._state.get(record.path)
+        is_dup = stored == signature
+        LOGGER.debug(
+            "Checked deduplication", extra={"path": record.path, "signature": signature, "is_duplicate": is_dup}
+        )
+        return is_dup
+
+    def mark_imported(self, record: LogRecord) -> None:
+        signature = record.signature
+        self._state[record.path] = signature
+        self._dirty = True
+        LOGGER.debug(
+            "Marked file as imported", extra={"path": record.path, "signature": signature}
+        )
+
+    def mark_many(self, records: Iterable[LogRecord]) -> None:
+        for record in records:
+            self.mark_imported(record)
+

--- a/services/h4m-bridge/h4m_bridge/scanner.py
+++ b/services/h4m-bridge/h4m_bridge/scanner.py
@@ -1,0 +1,136 @@
+"""Scan H4M storage for log files."""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, Optional
+
+LOGGER = logging.getLogger(__name__)
+
+SUPPORTED_FORMATS = {
+    "iq": (".iq", ".cfile", ".iq.tar", ".iq.gz"),
+    "decoded": (".json", ".ndjson", ".log", ".txt"),
+}
+
+
+@dataclass
+class LogRecord:
+    """Represents a log discovered on disk."""
+
+    path: str
+    log_type: str
+    size: int
+    modified_at: datetime
+    metadata: Dict[str, object]
+
+    @property
+    def signature(self) -> str:
+        return f"{self.size}:{int(self.modified_at.timestamp())}"
+
+
+class LogScanner:
+    """Find supported log files within a directory tree."""
+
+    def __init__(
+        self,
+        base_path: Path,
+        include_types: Optional[Iterable[str]] = None,
+    ) -> None:
+        self.base_path = Path(base_path)
+        if include_types is not None:
+            invalid = set(include_types) - set(SUPPORTED_FORMATS)
+            if invalid:
+                raise ValueError(f"Unsupported log types requested: {sorted(invalid)}")
+            self._extensions = {
+                ext
+                for key in include_types
+                for ext in SUPPORTED_FORMATS[key]
+            }
+        else:
+            self._extensions = {ext for exts in SUPPORTED_FORMATS.values() for ext in exts}
+
+    def scan(self) -> Iterator[LogRecord]:
+        if not self.base_path.exists():
+            LOGGER.warning("H4M storage path missing", extra={"base_path": str(self.base_path)})
+            return iter(())
+        for path in sorted(self.base_path.rglob("*")):
+            if not path.is_file():
+                continue
+            if path.suffix.lower() not in self._extensions:
+                continue
+            try:
+                record = self._create_record(path)
+            except Exception as exc:  # pragma: no cover - defensive logging
+                LOGGER.exception("Failed to parse metadata", extra={"path": str(path)}, exc_info=exc)
+                continue
+            LOGGER.debug(
+                "Discovered log file", extra={"path": record.path, "log_type": record.log_type, "size": record.size}
+            )
+            yield record
+
+    def _create_record(self, path: Path) -> LogRecord:
+        stat = path.stat()
+        log_type = self._detect_log_type(path)
+        metadata = self._extract_metadata(path, log_type)
+        return LogRecord(
+            path=str(path.resolve()),
+            log_type=log_type,
+            size=stat.st_size,
+            modified_at=datetime.fromtimestamp(stat.st_mtime),
+            metadata=metadata,
+        )
+
+    def _detect_log_type(self, path: Path) -> str:
+        suffix = path.suffix.lower()
+        for log_type, extensions in SUPPORTED_FORMATS.items():
+            if suffix in extensions:
+                return log_type
+        raise ValueError(f"Unsupported file extension: {suffix}")
+
+    def _extract_metadata(self, path: Path, log_type: str) -> Dict[str, object]:
+        metadata: Dict[str, object] = {
+            "filename": path.name,
+            "log_type": log_type,
+            "size": path.stat().st_size,
+            "modified_at": datetime.fromtimestamp(path.stat().st_mtime).isoformat(),
+        }
+        if log_type == "decoded" and path.suffix.lower() in {".json", ".ndjson"}:
+            try:
+                with path.open("r", encoding="utf-8") as handle:
+                    first_line = handle.readline().strip()
+                    if first_line:
+                        metadata.update(self._parse_json_line(first_line))
+            except (OSError, json.JSONDecodeError):
+                LOGGER.debug("Failed to parse JSON metadata", exc_info=True, extra={"path": str(path)})
+        elif log_type == "decoded":
+            with path.open("r", encoding="utf-8", errors="ignore") as handle:
+                metadata["preview"] = handle.readline().strip()
+        else:
+            metadata["iq_summary"] = self._summarize_iq_file(path)
+        return metadata
+
+    def _parse_json_line(self, line: str) -> Dict[str, object]:
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError:
+            return {"preview": line[:200]}
+        if isinstance(parsed, dict):
+            return parsed
+        return {"preview": line[:200]}
+
+    def _summarize_iq_file(self, path: Path) -> Dict[str, object]:
+        stat = path.stat()
+        summary = {
+            "size": stat.st_size,
+        }
+        try:
+            with path.open("rb") as handle:
+                header = handle.read(64)
+            summary["header_preview"] = header.hex()[:64]
+        except OSError:
+            summary["header_preview"] = ""
+        return summary
+

--- a/services/h4m-bridge/tests/conftest.py
+++ b/services/h4m-bridge/tests/conftest.py
@@ -1,0 +1,55 @@
+"""Test fixtures for H4M bridge."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Dict, Iterable
+
+import pytest
+
+BRIDGE_ROOT = Path(__file__).resolve().parents[1]
+if str(BRIDGE_ROOT) not in sys.path:
+    sys.path.insert(0, str(BRIDGE_ROOT))
+
+from h4m_bridge.dedup import FileDeduplicator  # noqa: E402  pylint: disable=wrong-import-position
+
+
+@pytest.fixture()
+def storage_dir(tmp_path: Path) -> Path:
+    base = tmp_path / "storage"
+    base.mkdir()
+    return base
+
+
+@pytest.fixture()
+def dedup_state_path(tmp_path: Path) -> Path:
+    return tmp_path / "dedup" / "state.json"
+
+
+def create_file(path: Path, content: bytes | str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(content, str):
+        path.write_text(content)
+    else:
+        path.write_bytes(content)
+
+
+@pytest.fixture()
+def sample_logs(storage_dir: Path) -> Dict[str, Path]:
+    paths = {
+        "iq": storage_dir / "captures" / "2024" / "sample.iq",
+        "decoded_json": storage_dir / "decoded" / "message.json",
+        "decoded_txt": storage_dir / "decoded" / "legacy.log",
+    }
+    create_file(paths["iq"], b"IQDATA" * 16)
+    create_file(paths["decoded_json"], json.dumps({"channel": "alpha", "frames": 12}) + "\n")
+    create_file(paths["decoded_txt"], "timestamp=1 level=INFO message=ok\n")
+    return paths
+
+
+@pytest.fixture()
+def deduplicator(dedup_state_path: Path) -> Iterable[FileDeduplicator]:
+    with FileDeduplicator(dedup_state_path) as dedup:
+        yield dedup
+

--- a/services/h4m-bridge/tests/test_bridge.py
+++ b/services/h4m-bridge/tests/test_bridge.py
@@ -1,0 +1,113 @@
+"""Tests for the bridge importer."""
+from __future__ import annotations
+
+import datetime
+import logging
+from typing import List
+from unittest import mock
+
+import pytest
+
+from h4m_bridge.bridge import BridgeImporter
+from h4m_bridge.scanner import LogRecord, LogScanner
+
+
+class DummyScanner(LogScanner):
+    def __init__(self, records):
+        self._records = records
+
+    def scan(self):
+        for record in self._records:
+            yield record
+
+
+@pytest.fixture()
+def patched_scanner(monkeypatch):
+    records: List = []
+
+    def factory(*args, **kwargs):
+        return DummyScanner(records)
+
+    monkeypatch.setattr("h4m_bridge.bridge.LogScanner", factory)
+    return records
+
+
+@pytest.fixture()
+def fake_record(sample_logs):
+    path = sample_logs["decoded_json"].resolve()
+    stat = path.stat()
+    return LogRecord(
+        path=str(path),
+        log_type="decoded",
+        size=stat.st_size,
+        modified_at=datetime.datetime.fromtimestamp(stat.st_mtime),
+        metadata={"channel": "alpha"},
+    )
+
+
+def test_importer_dry_run_skips_marking(sample_logs, storage_dir, dedup_state_path, fake_record, patched_scanner, caplog):
+    caplog.set_level(logging.INFO)
+    patched_scanner.append(fake_record)
+    with mock.patch("h4m_bridge.bridge.BridgeClient.post_event") as mocked_post:
+        importer = BridgeImporter(
+            storage_path=storage_dir,
+            backend_url="http://example",  # unused because patched
+            dedup_path=str(dedup_state_path),
+            dry_run=True,
+        )
+        summary = importer.run()
+
+    assert summary.imported == 1
+    assert mocked_post.call_count == 0
+    assert not dedup_state_path.exists()
+    assert any("Dry run" in rec.message for rec in caplog.records)
+
+
+def test_importer_marks_deduplicator(storage_dir, dedup_state_path, fake_record, patched_scanner):
+    patched_scanner.append(fake_record)
+    with mock.patch("h4m_bridge.bridge.BridgeClient.post_event") as mocked_post:
+        importer = BridgeImporter(
+            storage_path=storage_dir,
+            backend_url="http://example",
+            dedup_path=str(dedup_state_path),
+            dry_run=False,
+        )
+        summary = importer.run()
+
+    mocked_post.assert_called_once()
+    assert summary.imported == 1
+    assert dedup_state_path.exists()
+
+    # Second run should be skipped as duplicate
+    patched_scanner.clear()
+    patched_scanner.append(fake_record)
+    with mock.patch("h4m_bridge.bridge.BridgeClient.post_event") as mocked_post:
+        importer = BridgeImporter(
+            storage_path=storage_dir,
+            backend_url="http://example",
+            dedup_path=str(dedup_state_path),
+            dry_run=False,
+        )
+        summary = importer.run()
+
+    mocked_post.assert_not_called()
+    assert summary.duplicates == 1
+
+
+def test_importer_handles_client_errors(storage_dir, dedup_state_path, fake_record, patched_scanner, caplog):
+    caplog.set_level(logging.INFO)
+    patched_scanner.append(fake_record)
+    with mock.patch("h4m_bridge.bridge.BridgeClient.post_event", side_effect=RuntimeError("boom")):
+        importer = BridgeImporter(
+            storage_path=storage_dir,
+            backend_url="http://example",
+            dedup_path=str(dedup_state_path),
+            dry_run=False,
+        )
+        summary = importer.run()
+
+    assert summary.failed == 1
+    assert summary.imported == 0
+    assert "Failed to import log" in caplog.text
+    assert not dedup_state_path.exists()
+

--- a/services/h4m-bridge/tests/test_scanner.py
+++ b/services/h4m-bridge/tests/test_scanner.py
@@ -1,0 +1,27 @@
+"""Tests for the storage scanner."""
+from __future__ import annotations
+
+from h4m_bridge.scanner import LogScanner
+
+
+def test_scanner_discovers_supported_logs(sample_logs, storage_dir):
+    scanner = LogScanner(storage_dir)
+    records = list(scanner.scan())
+    paths = {record.path for record in records}
+
+    for expected in sample_logs.values():
+        assert str(expected.resolve()) in paths
+
+    decoded = [r for r in records if r.log_type == "decoded"]
+    assert any(r.metadata.get("channel") == "alpha" for r in decoded)
+    assert any("timestamp=1" in r.metadata.get("preview", "") for r in decoded)
+
+    iq_records = [r for r in records if r.log_type == "iq"]
+    assert iq_records
+    assert all("iq_summary" in r.metadata for r in iq_records)
+
+
+def test_scanner_handles_missing_storage(tmp_path):
+    scanner = LogScanner(tmp_path / "missing")
+    assert list(scanner.scan()) == []
+


### PR DESCRIPTION
## Summary
- add a Python-based H4M bridge service that scans /mnt/h4m for IQ and decoded logs
- implement metadata extraction, deduplication, dry-run handling, and structured logging
- include pytest fixtures covering scanning, importing, and error handling behaviour

## Testing
- pytest services/h4m-bridge/tests

------
https://chatgpt.com/codex/tasks/task_e_68f28fb4e7948323883f3a43d3c9efe4