### PR TITLE
Add telemetry ingest services and document infrastructure variables

### DIFF
--- a/deploy/udev/99-vtoc.rules
+++ b/deploy/udev/99-vtoc.rules
@@ -1,0 +1,10 @@
+# vTOC telemetry device access
+# Allow GPS receivers connected via USB serial adapters.
+SUBSYSTEM=="tty", KERNEL=="ttyUSB*", MODE="0666", GROUP="dialout", TAG+="uaccess"
+
+# Allow RTL-SDR USB receivers (Realtek RTL2832U family).
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0bda", ATTRS{idProduct}=="2838", MODE="0666", GROUP="plugdev", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0bda", ATTRS{idProduct}=="2832", MODE="0666", GROUP="plugdev", TAG+="uaccess"
+
+# Optional local overrides can be placed in /etc/udev/rules.d/99-vtoc-local.rules
+# to refine permissions for specific stations or hardware revisions.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,5 +47,45 @@ services:
     depends_on:
       - backend
 
+  gps-ingest:
+    image: ${VTOC_IMAGE_REPO:-ghcr.io/pr-cybr/vtoc}/gps-ingest:${VTOC_IMAGE_TAG:-main}
+    pull_policy: always
+    environment:
+      BACKEND_BASE_URL: ${BACKEND_BASE_URL:-http://backend:8080}
+      GPS_SERIAL_DEVICE: ${GPS_SERIAL_DEVICE:-/dev/ttyUSB0}
+      GPS_BAUD_RATE: ${GPS_BAUD_RATE:-9600}
+      GPS_SOURCE_SLUG: ${GPS_SOURCE_SLUG:-station-gps}
+    devices:
+      - "${GPS_SERIAL_DEVICE:-/dev/ttyUSB0}:${GPS_SERIAL_DEVICE:-/dev/ttyUSB0}"
+    depends_on:
+      - backend
+
+  adsb-ingest:
+    image: ${VTOC_IMAGE_REPO:-ghcr.io/pr-cybr/vtoc}/adsb-ingest:${VTOC_IMAGE_TAG:-main}
+    pull_policy: always
+    environment:
+      BACKEND_BASE_URL: ${BACKEND_BASE_URL:-http://backend:8080}
+      ADSB_FEED_URL: ${ADSB_FEED_URL:-http://dump1090:8080/data/aircraft.json}
+      ADSB_SOURCE_SLUG: ${ADSB_SOURCE_SLUG:-station-adsb}
+      RTLSDR_DEVICE_SERIAL: ${RTLSDR_DEVICE_SERIAL:-}
+    devices:
+      - "/dev/bus/usb:/dev/bus/usb"
+    depends_on:
+      - backend
+
+  h4m-bridge:
+    image: ${VTOC_IMAGE_REPO:-ghcr.io/pr-cybr/vtoc}/h4m-bridge:${VTOC_IMAGE_TAG:-main}
+    pull_policy: always
+    environment:
+      BACKEND_BASE_URL: ${BACKEND_BASE_URL:-http://backend:8080}
+      H4M_SERIAL_DEVICE: ${H4M_SERIAL_DEVICE:-/dev/ttyUSB1}
+      H4M_BAUD_RATE: ${H4M_BAUD_RATE:-115200}
+      H4M_CHANNEL: ${H4M_CHANNEL:-station-h4m}
+      H4M_SOURCE_SLUG: ${H4M_SOURCE_SLUG:-station-h4m}
+    devices:
+      - "${H4M_SERIAL_DEVICE:-/dev/ttyUSB1}:${H4M_SERIAL_DEVICE:-/dev/ttyUSB1}"
+    depends_on:
+      - backend
+
 volumes:
   postgres_data:

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,0 +1,35 @@
+# Infrastructure Overview
+
+The `infrastructure/` directory contains automation for provisioning backing services and
+supplemental assets that operators deploy alongside vTOC. This document highlights the
+telemetry ingest additions introduced for the GPS, ADS-B, and H4M bridge services.
+
+## Terraform secrets and variables
+
+Terraform templates under `infrastructure/terraform/` expose variables that are mapped to
+runtime secrets via `secrets.tf`. In addition to the existing backend and frontend
+configuration, the following variables drive the new telemetry ingest containers:
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `gps_serial_device` | Serial device path exposed to the GPS ingest container. | `/dev/ttyUSB0` |
+| `gps_baud_rate` | Baud rate for the GPS serial device. | `9600` |
+| `gps_source_slug` | Telemetry source slug recorded by the GPS ingest service. | `station-gps` |
+| `adsb_feed_url` | URL for retrieving ADS-B JSON feeds (e.g., dump1090). | `http://dump1090:8080/data/aircraft.json` |
+| `adsb_source_slug` | Telemetry source slug recorded by the ADS-B ingest service. | `station-adsb` |
+| `rtlsdr_device_serial` | Optional RTL-SDR serial number to pin the USB receiver. | _(empty)_ |
+| `h4m_serial_device` | Serial device path exposed to the H4M bridge container. | `/dev/ttyUSB1` |
+| `h4m_baud_rate` | Baud rate for the H4M bridge serial interface. | `115200` |
+| `h4m_channel` | Channel identifier announced to the backend by the H4M bridge. | `station-h4m` |
+| `h4m_source_slug` | Telemetry source slug recorded by the H4M bridge service. | `station-h4m` |
+
+When `terraform output -json fly_secret_map` is rendered these keys are now included,
+allowing operators to push consistent secrets into Fly.io or other target platforms.
+Override any value within `terraform.tfvars` or environment-specific tfvars files.
+
+## Udev rules for telemetry devices
+
+Udev rules under `deploy/udev/99-vtoc.rules` grant non-root access to USB serial adapters
+and RTL-SDR receivers commonly used by the ingest services. Operators may add additional
+rules under `/etc/udev/rules.d/99-vtoc-local.rules` to tailor permissions for unique
+hardware revisions without modifying the shared rule set.

--- a/infrastructure/terraform/secrets.tf
+++ b/infrastructure/terraform/secrets.tf
@@ -107,12 +107,26 @@ locals {
     var.additional_frontend_env,
   )
 
+  ingest_env = {
+    GPS_SERIAL_DEVICE     = var.gps_serial_device
+    GPS_BAUD_RATE         = tostring(var.gps_baud_rate)
+    GPS_SOURCE_SLUG       = var.gps_source_slug
+    ADSB_FEED_URL         = var.adsb_feed_url
+    ADSB_SOURCE_SLUG      = var.adsb_source_slug
+    RTLSDR_DEVICE_SERIAL  = var.rtlsdr_device_serial
+    H4M_SERIAL_DEVICE     = var.h4m_serial_device
+    H4M_BAUD_RATE         = tostring(var.h4m_baud_rate)
+    H4M_CHANNEL           = var.h4m_channel
+    H4M_SOURCE_SLUG       = var.h4m_source_slug
+  }
+
   fly_secret_map = merge(
     local.backend_env,
     local.backend_database_env_public_labeled,
     {
       SUPABASE_ANON_KEY = local.supabase.anon_key
     },
+    local.ingest_env,
     var.additional_fly_secrets,
   )
 

--- a/infrastructure/terraform/terraform.tfvars.example
+++ b/infrastructure/terraform/terraform.tfvars.example
@@ -32,3 +32,15 @@ zerotier_network_id        = ""
 tailscale_auth_key         = ""
 additional_fly_secrets     = {}
 additional_frontend_env    = {}
+
+# Telemetry ingest defaults
+gps_serial_device          = "/dev/ttyUSB0"
+gps_baud_rate              = 9600
+gps_source_slug            = "station-gps"
+adsb_feed_url              = "http://dump1090:8080/data/aircraft.json"
+adsb_source_slug           = "station-adsb"
+rtlsdr_device_serial       = ""
+h4m_serial_device          = "/dev/ttyUSB1"
+h4m_baud_rate              = 115200
+h4m_channel                = "station-h4m"
+h4m_source_slug            = "station-h4m"

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -250,3 +250,63 @@ variable "additional_frontend_env" {
   type        = map(string)
   default     = {}
 }
+
+variable "gps_serial_device" {
+  description = "Serial device path presented to the GPS ingest container."
+  type        = string
+  default     = "/dev/ttyUSB0"
+}
+
+variable "gps_baud_rate" {
+  description = "Baud rate used when reading from the GPS serial device."
+  type        = number
+  default     = 9600
+}
+
+variable "gps_source_slug" {
+  description = "Telemetry source slug recorded by the GPS ingest service."
+  type        = string
+  default     = "station-gps"
+}
+
+variable "adsb_feed_url" {
+  description = "URL for ADS-B JSON feeds (e.g., dump1090)."
+  type        = string
+  default     = "http://dump1090:8080/data/aircraft.json"
+}
+
+variable "adsb_source_slug" {
+  description = "Telemetry source slug recorded by the ADS-B ingest service."
+  type        = string
+  default     = "station-adsb"
+}
+
+variable "rtlsdr_device_serial" {
+  description = "Optional RTL-SDR device serial to pin within the ADS-B ingest container."
+  type        = string
+  default     = ""
+}
+
+variable "h4m_serial_device" {
+  description = "Serial device path presented to the H4M bridge container."
+  type        = string
+  default     = "/dev/ttyUSB1"
+}
+
+variable "h4m_baud_rate" {
+  description = "Baud rate used by the H4M bridge serial interface."
+  type        = number
+  default     = 115200
+}
+
+variable "h4m_channel" {
+  description = "Channel identifier for the H4M bridge to register with the backend."
+  type        = string
+  default     = "station-h4m"
+}
+
+variable "h4m_source_slug" {
+  description = "Telemetry source slug recorded by the H4M bridge service."
+  type        = string
+  default     = "station-h4m"
+}


### PR DESCRIPTION
## Summary
- add gps-ingest, adsb-ingest, and h4m-bridge services with device and environment mappings to docker-compose
- provide udev rules granting USB access for GPS and RTL-SDR ingest hardware
- surface new telemetry ingest variables in Terraform secrets and document their usage

## Testing
- docker compose config *(fails: docker CLI unavailable in build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f28fbf59f08323bc5a8549faf05b68