### PR TITLE
Add workflow to build live images with OIDC

### DIFF
--- a/.github/workflows/build-image-live.yml
+++ b/.github/workflows/build-image-live.yml
@@ -1,0 +1,97 @@
+name: Build Live Images
+
+on:
+  push:
+    branches:
+      - live
+    paths-ignore:
+      - 'infrastructure/**'
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_REPOSITORY: ${{ github.repository }}
+
+jobs:
+  publish:
+    name: Build and publish container images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Lowercase image repository
+        id: repo
+        run: |
+          set -euo pipefail
+          echo "name=$(echo "${IMAGE_REPOSITORY}" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Authenticate to GHCR
+        id: ghcr
+        uses: actions/registry-login@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ steps.ghcr.outputs.registry }}
+          username: ${{ steps.ghcr.outputs.username }}
+          password: ${{ steps.ghcr.outputs.password }}
+
+      - name: Compute image tags
+        id: meta
+        env:
+          REGISTRY: ${{ env.REGISTRY }}
+          IMAGE_REPO: ${{ steps.repo.outputs.name }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          backend_tags="${REGISTRY}/${IMAGE_REPO}/backend:${SHA}\n${REGISTRY}/${IMAGE_REPO}/backend:live"
+          frontend_tags="${REGISTRY}/${IMAGE_REPO}/frontend:${SHA}\n${REGISTRY}/${IMAGE_REPO}/frontend:live"
+          scraper_tags="${REGISTRY}/${IMAGE_REPO}/scraper:${SHA}\n${REGISTRY}/${IMAGE_REPO}/scraper:live"
+          {
+            echo "backend_tags<<TAGS"
+            echo "${backend_tags}"
+            echo TAGS
+            echo "frontend_tags<<TAGS"
+            echo "${frontend_tags}"
+            echo TAGS
+            echo "scraper_tags<<TAGS"
+            echo "${scraper_tags}"
+            echo TAGS
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.backend_tags }}
+
+      - name: Build and push frontend image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.frontend_tags }}
+
+      - name: Build and push scraper image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./agents/scraper
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.scraper_tags }}


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds and pushes the backend, frontend, and scraper images to GHCR when changes land on the `live` branch
- configure the job to authenticate with GHCR using the GitHub OIDC token, leverage Buildx, and ignore infrastructure-only pushes

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68f2964cc3f08323bd6e8ae6517920c2