### PR TITLE
Add .env glob to Terraform ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ override.tf
 override.tf.json
 *_override.tf
 *_override.tf.json
+.env.*
 
 # Ansible
 *.retry


### PR DESCRIPTION
## Summary
- add the `.env.*` glob to the Terraform section of the root `.gitignore`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f296518acc8323874a9f58a287b0e5