### PR TITLE
Document Terraform Cloud managed Fly.io deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ mission log while respecting station roles:
 An end-to-end overview is available in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) together with updated diagrams in
 [`docs/DIAGRAMS.md`](docs/DIAGRAMS.md).
 
+## Deploy (Terraform Cloud on Fly.io)
+
+The repository keeps two long-lived branches with distinct deployment roles:
+
+* `main` retains the generic development defaults used by contributors when iterating locally or in preview environments.
+* `live` is managed by Terraform Cloud, which applies the Fly.io workspace in [`infrastructure/README-infra.md`](infrastructure/README-infra.md) to promote approved container images and environment configuration.
+
+The Terraform Cloud workflow handles Fly.io secrets, release rollbacks, and keeps the `live` branch fast-forwarded to the exact commit running in production. Operators can inspect the job history, trigger re-runs, or apply manual overrides directly from Terraform Cloud using the linked infrastructure guide.
+
 ## Deployment modes
 
 | Mode | Command | Description |


### PR DESCRIPTION
## Summary
- add a README section that summarizes the Terraform Cloud workflow backing the Fly.io deployment
- clarify the branch roles for main (dev defaults) and live (Terraform-managed production)

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f2965540a08323bf39b422dace1b3a