### PR TITLE
Support config bundle overrides in container setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,39 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      - name: Container setup fallback (no Terraform)
+        run: |
+          set -euo pipefail
+          PY_DIR="$(dirname "$(command -v python)")"
+          CLEAN_PATH="$PATH"
+          if command -v terraform >/dev/null 2>&1; then
+            TF_DIR="$(dirname "$(command -v terraform)")"
+            CLEAN_PATH="$(TF_DIR="$TF_DIR" python - <<'PY'
+import os
+import sys
+
+path = os.environ.get('PATH', '')
+tf_dir = os.environ.get('TF_DIR')
+parts = []
+for entry in path.split(':'):
+    if not entry:
+        continue
+    if tf_dir and os.path.abspath(entry) == os.path.abspath(tf_dir):
+        continue
+    parts.append(entry)
+sys.stdout.write(':'.join(parts))
+PY
+)"
+          fi
+          if [[ -n "$PY_DIR" && ":$CLEAN_PATH:" != *":$PY_DIR:"* ]]; then
+            CLEAN_PATH="$CLEAN_PATH:$PY_DIR"
+          fi
+          export PATH="$CLEAN_PATH"
+          if command -v terraform >/dev/null 2>&1; then
+            echo "Terraform still available on PATH" >&2
+            exit 1
+          fi
+          ./scripts/setup_container.sh --build-local
       - name: Install Python dependencies
         run: python -m pip install -r backend/requirements.txt
       - name: Python lint

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -111,6 +111,11 @@ VTOC_IMAGE_TAG=main docker compose up
 If you need to build services locally, regenerate the compose file with `./scripts/setup_container.sh --build-local` so the
 `build:` blocks are reinstated.
 
+The container helper now supports a Terraform-free flow: it first checks the forwarded config (`--config` or
+`VTOC_CONFIG_JSON`) for a `configBundle` override, then falls back to [`scripts/defaults/config_bundle.local.json`](../scripts/defaults/config_bundle.local.json)
+when Terraform outputs are unavailable. Copy that file, replace the placeholder secrets, and pass it through the setup CLI to
+boot the stack without Terraform — the override takes precedence even when you opt into `--build-local` builds.
+
 ### 4. Verify installation
 
 ```bash

--- a/scripts/defaults/config_bundle.local.json
+++ b/scripts/defaults/config_bundle.local.json
@@ -1,0 +1,105 @@
+{
+  "postgres": {
+    "database": "vtoc",
+    "user": "vtoc",
+    "password": "vtocpass",
+    "host": "database",
+    "internal_host": "database",
+    "port": 5432
+  },
+  "backend": {
+    "internal_database_env": {
+      "DATABASE_URL": "postgresql+psycopg2://vtoc:vtocpass@database:5432/vtoc",
+      "DATABASE_URL_TOC_S1": "postgresql+psycopg2://vtoc:vtocpass@database:5432/vtoc?options=-csearch_path%3Dtoc_s1",
+      "DATABASE_URL_TOC_S2": "postgresql+psycopg2://vtoc:vtocpass@database:5432/vtoc?options=-csearch_path%3Dtoc_s2",
+      "DATABASE_URL_TOC_S3": "postgresql+psycopg2://vtoc:vtocpass@database:5432/vtoc?options=-csearch_path%3Dtoc_s3",
+      "DATABASE_URL_TOC_S4": "postgresql+psycopg2://vtoc:vtocpass@database:5432/vtoc?options=-csearch_path%3Dtoc_s4"
+    },
+    "env": {
+      "DATABASE_URL": "postgresql+psycopg2://vtoc:vtocpass@database:5432/vtoc",
+      "DATABASE_URL_TOC_S1": "postgresql+psycopg2://vtoc:vtocpass@database:5432/vtoc?options=-csearch_path%3Dtoc_s1",
+      "DATABASE_URL_TOC_S2": "postgresql+psycopg2://vtoc:vtocpass@database:5432/vtoc?options=-csearch_path%3Dtoc_s2",
+      "DATABASE_URL_TOC_S3": "postgresql+psycopg2://vtoc:vtocpass@database:5432/vtoc?options=-csearch_path%3Dtoc_s3",
+      "DATABASE_URL_TOC_S4": "postgresql+psycopg2://vtoc:vtocpass@database:5432/vtoc?options=-csearch_path%3Dtoc_s4",
+      "AGENTKIT_API_BASE_URL": "https://agentkit.example.com/api",
+      "AGENTKIT_API_KEY": "",
+      "AGENTKIT_ORG_ID": "",
+      "AGENTKIT_TIMEOUT_SECONDS": "30",
+      "CHATKIT_WEBHOOK_SECRET": "",
+      "CHATKIT_ALLOWED_TOOLS": "",
+      "CHATKIT_API_KEY": "",
+      "CHATKIT_ORG_ID": "",
+      "SUPABASE_URL": "",
+      "SUPABASE_PROJECT_REF": "",
+      "SUPABASE_SERVICE_ROLE_KEY": "",
+      "SUPABASE_JWT_SECRET": ""
+    },
+    "env_public": {
+      "DATABASE_URL": "postgresql+psycopg2://vtoc:vtocpass@database:5432/vtoc",
+      "DATABASE_URL_TOC_S1": "postgresql+psycopg2://vtoc:vtocpass@database:5432/vtoc?options=-csearch_path%3Dtoc_s1",
+      "DATABASE_URL_TOC_S2": "postgresql+psycopg2://vtoc:vtocpass@database:5432/vtoc?options=-csearch_path%3Dtoc_s2",
+      "DATABASE_URL_TOC_S3": "postgresql+psycopg2://vtoc:vtocpass@database:5432/vtoc?options=-csearch_path%3Dtoc_s3",
+      "DATABASE_URL_TOC_S4": "postgresql+psycopg2://vtoc:vtocpass@database:5432/vtoc?options=-csearch_path%3Dtoc_s4",
+      "AGENTKIT_API_BASE_URL": "https://agentkit.example.com/api",
+      "AGENTKIT_API_KEY": "",
+      "AGENTKIT_ORG_ID": "",
+      "AGENTKIT_TIMEOUT_SECONDS": "30",
+      "CHATKIT_WEBHOOK_SECRET": "",
+      "CHATKIT_ALLOWED_TOOLS": "",
+      "CHATKIT_API_KEY": "",
+      "CHATKIT_ORG_ID": "",
+      "SUPABASE_URL": "",
+      "SUPABASE_PROJECT_REF": "",
+      "SUPABASE_SERVICE_ROLE_KEY": "",
+      "SUPABASE_JWT_SECRET": ""
+    }
+  },
+  "scraper": {
+    "env": {
+      "BACKEND_BASE_URL": "http://backend:8080"
+    }
+  },
+  "frontend": {
+    "env": {
+      "VITE_PORT": "5173",
+      "VITE_API_BASE_URL": "http://localhost:8080",
+      "VITE_MAP_TILES_URL": "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+      "VITE_MAP_ATTRIBUTION": "© OpenStreetMap contributors",
+      "VITE_DEFAULT_DIV": "PR-SJU",
+      "VITE_RSS_ENABLED": "true",
+      "VITE_CHAT_ENABLED": "true",
+      "VITE_CHATKIT_WIDGET_URL": "https://cdn.chatkit.example.com/widget.js",
+      "VITE_CHATKIT_API_KEY": "",
+      "VITE_CHATKIT_TELEMETRY_CHANNEL": "vtoc-intel",
+      "VITE_AGENTKIT_ORG_ID": "",
+      "VITE_AGENTKIT_DEFAULT_STATION_CONTEXT": "PR-SJU",
+      "VITE_AGENTKIT_API_BASE_PATH": "/api/v1/agent-actions",
+      "VITE_SUPABASE_URL": "",
+      "VITE_SUPABASE_ANON_KEY": "",
+      "VITE_SUPABASE_TELEMETRY_TABLE": "telemetry_events"
+    }
+  },
+  "supabase": {
+    "project_ref": "",
+    "api_url": "",
+    "anon_key": "",
+    "service_role_key": "",
+    "jwt_secret": ""
+  },
+  "fly": {
+    "runtime": {
+      "app_name": "",
+      "api_token": "",
+      "ghcr_username": "",
+      "ghcr_token": "",
+      "backend_image": "",
+      "frontend_image": "",
+      "scraper_image": ""
+    },
+    "secrets_env": {}
+  },
+  "optional_integrations": {
+    "zerotier_network_id": "",
+    "tailscale_auth_key": ""
+  }
+}

--- a/scripts/examples/container.json
+++ b/scripts/examples/container.json
@@ -5,5 +5,87 @@
     "postgres": true,
     "n8n": false,
     "wazuh": false
+  },
+  "configBundle": {
+    "postgres": {
+      "database": "vtoc",
+      "user": "vtoc",
+      "password": "vtocpass",
+      "host": "database",
+      "internal_host": "database",
+      "port": 5432
+    },
+    "backend": {
+      "internal_database_env": {
+        "DATABASE_URL": "postgresql+psycopg2://vtoc:vtocpass@database:5432/vtoc",
+        "DATABASE_URL_TOC_S1": "postgresql+psycopg2://vtoc:vtocpass@database:5432/vtoc?options=-csearch_path%3Dtoc_s1",
+        "DATABASE_URL_TOC_S2": "postgresql+psycopg2://vtoc:vtocpass@database:5432/vtoc?options=-csearch_path%3Dtoc_s2",
+        "DATABASE_URL_TOC_S3": "postgresql+psycopg2://vtoc:vtocpass@database:5432/vtoc?options=-csearch_path%3Dtoc_s3",
+        "DATABASE_URL_TOC_S4": "postgresql+psycopg2://vtoc:vtocpass@database:5432/vtoc?options=-csearch_path%3Dtoc_s4"
+      },
+      "env": {
+        "DATABASE_URL": "postgresql+psycopg2://vtoc:vtocpass@database:5432/vtoc",
+        "DATABASE_URL_TOC_S1": "postgresql+psycopg2://vtoc:vtocpass@database:5432/vtoc?options=-csearch_path%3Dtoc_s1",
+        "DATABASE_URL_TOC_S2": "postgresql+psycopg2://vtoc:vtocpass@database:5432/vtoc?options=-csearch_path%3Dtoc_s2",
+        "DATABASE_URL_TOC_S3": "postgresql+psycopg2://vtoc:vtocpass@database:5432/vtoc?options=-csearch_path%3Dtoc_s3",
+        "DATABASE_URL_TOC_S4": "postgresql+psycopg2://vtoc:vtocpass@database:5432/vtoc?options=-csearch_path%3Dtoc_s4",
+        "AGENTKIT_API_BASE_URL": "https://agentkit.example.com/api",
+        "AGENTKIT_API_KEY": "replace-me",
+        "AGENTKIT_ORG_ID": "replace-me",
+        "AGENTKIT_TIMEOUT_SECONDS": "30",
+        "CHATKIT_WEBHOOK_SECRET": "replace-me",
+        "CHATKIT_ALLOWED_TOOLS": "",
+        "CHATKIT_API_KEY": "replace-me",
+        "CHATKIT_ORG_ID": "replace-me",
+        "SUPABASE_URL": "https://your-project.supabase.co",
+        "SUPABASE_PROJECT_REF": "your-project-ref",
+        "SUPABASE_SERVICE_ROLE_KEY": "replace-me",
+        "SUPABASE_JWT_SECRET": "replace-me"
+      },
+      "env_public": {
+        "DATABASE_URL": "postgresql+psycopg2://vtoc:vtocpass@database:5432/vtoc",
+        "DATABASE_URL_TOC_S1": "postgresql+psycopg2://vtoc:vtocpass@database:5432/vtoc?options=-csearch_path%3Dtoc_s1",
+        "DATABASE_URL_TOC_S2": "postgresql+psycopg2://vtoc:vtocpass@database:5432/vtoc?options=-csearch_path%3Dtoc_s2",
+        "DATABASE_URL_TOC_S3": "postgresql+psycopg2://vtoc:vtocpass@database:5432/vtoc?options=-csearch_path%3Dtoc_s3",
+        "DATABASE_URL_TOC_S4": "postgresql+psycopg2://vtoc:vtocpass@database:5432/vtoc?options=-csearch_path%3Dtoc_s4",
+        "AGENTKIT_API_BASE_URL": "https://agentkit.example.com/api",
+        "AGENTKIT_API_KEY": "replace-me",
+        "AGENTKIT_ORG_ID": "replace-me",
+        "AGENTKIT_TIMEOUT_SECONDS": "30",
+        "CHATKIT_WEBHOOK_SECRET": "replace-me",
+        "CHATKIT_ALLOWED_TOOLS": "",
+        "CHATKIT_API_KEY": "replace-me",
+        "CHATKIT_ORG_ID": "replace-me",
+        "SUPABASE_URL": "https://your-project.supabase.co",
+        "SUPABASE_PROJECT_REF": "your-project-ref",
+        "SUPABASE_SERVICE_ROLE_KEY": "replace-me",
+        "SUPABASE_JWT_SECRET": "replace-me"
+      }
+    },
+    "scraper": {
+      "env": {
+        "BACKEND_BASE_URL": "http://backend:8080"
+      }
+    },
+    "frontend": {
+      "env": {
+        "VITE_PORT": "5173",
+        "VITE_API_BASE_URL": "http://localhost:8080",
+        "VITE_MAP_TILES_URL": "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+        "VITE_MAP_ATTRIBUTION": "© OpenStreetMap contributors",
+        "VITE_DEFAULT_DIV": "PR-SJU",
+        "VITE_RSS_ENABLED": "true",
+        "VITE_CHAT_ENABLED": "true",
+        "VITE_CHATKIT_WIDGET_URL": "https://cdn.chatkit.example.com/widget.js",
+        "VITE_CHATKIT_API_KEY": "replace-me",
+        "VITE_CHATKIT_TELEMETRY_CHANNEL": "vtoc-intel",
+        "VITE_AGENTKIT_ORG_ID": "replace-me",
+        "VITE_AGENTKIT_DEFAULT_STATION_CONTEXT": "PR-SJU",
+        "VITE_AGENTKIT_API_BASE_PATH": "/api/v1/agent-actions",
+        "VITE_SUPABASE_URL": "https://your-project.supabase.co",
+        "VITE_SUPABASE_ANON_KEY": "replace-me",
+        "VITE_SUPABASE_TELEMETRY_TABLE": "telemetry_events"
+      }
+    }
   }
 }

--- a/scripts/inputs.schema.json
+++ b/scripts/inputs.schema.json
@@ -24,6 +24,10 @@
         "region": { "type": "string" }
       },
       "additionalProperties": false
+    },
+    "configBundle": {
+      "type": "object",
+      "description": "Optional override matching the Terraform config_bundle output. See scripts/defaults/config_bundle.local.json for the expected shape."
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
## Summary
- add config bundle override detection and Terraform-free fallback handling to `scripts/setup_container.sh`
- check in a default `config_bundle.local.json` that mirrors the development settings used by the generator
- document the new `configBundle` option in the schema, example config, README, and Quick Start guide
- extend CI with a smoke test that exercises `setup_container.sh --build-local` without Terraform on the `PATH`

## Testing
- ./scripts/setup_container.sh --build-local
- VTOC_CONFIG_JSON="$(python - <<'PY'
import json
from pathlib import Path
data = json.loads(Path('scripts/defaults/config_bundle.local.json').read_text())
data['backend']['env']['AGENTKIT_API_KEY'] = 'override-key'
print(json.dumps({'configBundle': data}))
PY
)" ./scripts/setup_container.sh --build-local


------
https://chatgpt.com/codex/tasks/task_e_68f2ac3fd64c83239824847ce8013ca2