### PR TITLE
Add workflow documentation and cross-links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,8 +136,9 @@ make compose-down
 - Update relevant docs in the `docs/` directory when introducing user-facing changes.
 - Cross-link new sections from `README.md` and [`docs/CHANGELOG.md`](docs/CHANGELOG.md).
 - Include station role considerations when modifying setup instructions.
-- Monitor the "Discussion: publish deployment summary" workflow after merging to `main`. If it fails or needs to be re-run,
-  trigger the job manually via **Actions → Run workflow** so the GitHub Discussion summary stays current.
+- Monitor the [`Main discussion summary` workflow](docs/workflows/main-discussion-summary.md) after merging to `main`. If it
+  fails or needs to be re-run, trigger the job manually via **Actions → Run workflow** so the GitHub Discussion summary stays
+  current.
 
 ## Submitting changes
 

--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ Supply configuration through `--config path.json` or `--config-json '{...}'`. Th
 
 Codex CLI is detected automatically: if the `codex` binary exists, the setup scripts use `codex interpolate` for variable
 expansion; otherwise they fall back to portable Bash implementations. Commits that land on `main` now trigger the
-[discussion-summary workflow](.github/workflows/discussion-summary.yml) which renders a release note style update in GitHub
-Discussions using Codex. Configure the `CODEX_API_KEY` and `DOCS_DISCUSSION_CATEGORY_ID` secrets/variables in the repository
-so the automation can authenticate and target the correct discussion category.
+[`Main discussion summary` workflow](docs/workflows/main-discussion-summary.md) which renders a release note style update in
+GitHub Discussions using Codex. Configure the `CODEX_API_KEY` and `DOCS_DISCUSSION_CATEGORY_ID` secrets/variables in the
+repository so the automation can authenticate and target the correct discussion category.
 
 ## Containers and orchestration
 
@@ -106,7 +106,7 @@ so the automation can authenticate and target the correct discussion category.
 * `fly.toml` — Fly.io deployment descriptor for the backend container deployed from the `live` branch
 
 Images are built and pushed to GHCR via GitHub Actions as part of [`ci.yml`](.github/workflows/ci.yml) and the release-focused
-[`publish-containers.yml`](.github/workflows/publish-containers.yml) workflow:
+[`Publish Containers` workflow](docs/workflows/publish-containers.md):
 
 - `ghcr.io/<repo>/frontend` (Vite static bundle served by nginx)
 - `ghcr.io/<repo>/backend` (FastAPI + Uvicorn on port 8080)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,7 @@ existing operators. Cross-links point to updated documentation for deeper detail
 - Updated setup scripts (`make setup-local`, `make setup-container`, `make setup-cloud`) to provision ChatKit resources.
 - Revamped documentation: [`README.md`](../README.md), [`docs/QUICKSTART.md`](QUICKSTART.md),
   [`docs/ARCHITECTURE.md`](ARCHITECTURE.md), [`docs/DEPLOYMENT.md`](DEPLOYMENT.md), [`docs/TELEMETRY_CONNECTORS.md`](TELEMETRY_CONNECTORS.md).
-- Introduced an automated discussion summary workflow that posts release notes to GitHub Discussions when `main` is updated.
+- Introduced an automated discussion summary workflow that posts release notes to GitHub Discussions when `main` is updated (see [`Main discussion summary`](workflows/main-discussion-summary.md)).
 
 ## Migration steps
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -59,11 +59,11 @@ To stop and clean up run `python -m scripts.bootstrap_cli compose down` (or the 
 
 ### Published images and demo refreshes
 
-The `Publish Containers` GitHub Actions workflow builds the backend, frontend, and scraper images after the full test matrix
-passes. Each run uploads a `docker-compose.generated.yml` artifact that pins the newly published tags; when a Git tag is
-created the same file is attached to the release assets. Prior to workshops or demos you can either download the latest compose
-artifact from the workflow run or trigger the workflow manually (optionally providing a release tag). Once the artifact is in
-hand, run:
+The [`Publish Containers` workflow](workflows/publish-containers.md) builds the backend, frontend, and scraper images after the
+full test matrix passes. Each run uploads a `docker-compose.generated.yml` artifact that pins the newly published tags; when a
+Git tag is created the same file is attached to the release assets. Prior to workshops or demos you can either download the
+latest compose artifact from the workflow run or trigger the workflow manually (optionally providing a release tag). Once the
+artifact is in hand, run:
 
 ```bash
 scripts/setup_container.sh --pull --image-tag <tag-from-workflow>
@@ -71,7 +71,8 @@ docker compose -f docker-compose.generated.yml up -d
 ```
 
 The `--pull` flag updates local caches and rewrites the manifest to point at the published images so attendees can launch the
-stack without rebuilding containers.
+stack without rebuilding containers. The [`Build Live Images` workflow](workflows/build-image-live.md) keeps Fly.io aligned by
+retagging the same containers with `:live` whenever the hardened branch advances.
 
 ## Docker Swarm (production)
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -84,7 +84,7 @@ When editing existing items:
 
 ## Automation behavior
 
-Codex and GitHub workflows will mutate the backlog with the following rules:
+Codex and GitHub workflows will mutate the backlog with the following rules (see [`Project backlog plan`](workflows/project-backlog-plan.md), [`Project Ready Execute`](workflows/project-ready-execute.md), and [`Project done discussion`](workflows/project-done-discussion.md) for implementation details):
 
 - **Codex plan generation**: When a Codex plan is created from a backlog item,
   the automation writes the plan URL to `codex_plan_url`, records a list of

--- a/docs/workflows/build-image-live.md
+++ b/docs/workflows/build-image-live.md
@@ -1,0 +1,26 @@
+# Build Live Images workflow
+
+The **Build Live Images** workflow publishes production-tagged containers whenever the hardened `live` branch changes.
+
+## Triggers
+- `push` events to the `live` branch, ignoring updates under `infrastructure/**`.
+
+## Required secrets and variables
+- Relies on the repository `GITHUB_TOKEN` for `actions/registry-login@v1` and `docker/login-action@v3`.
+- No additional secrets are required because the workflow uses OIDC-backed authentication to GHCR.
+
+## Jobs and major steps
+### `publish` job
+- Checks out the repo in `Checkout repository` and normalizes the namespace via `Lowercase image repository`.
+- Enables cross-platform builds with `Set up QEMU` and `Set up Docker Buildx`.
+- Authenticates to the registry through `Authenticate to GHCR` and `Log in to GHCR`.
+- Computes dual `:SHA` and `:live` tags in `Compute image tags`.
+- Builds and pushes each service image with the three `Build and push … image` steps, targeting `linux/amd64` and `linux/arm64`.
+
+## Expected artifacts
+- No artifacts are uploaded; the job's output is the set of images tagged `:live` and `:<commit SHA>` for backend, frontend, and scraper.
+
+## Common failure modes
+- GHCR authentication problems (`Authenticate to GHCR` or `Log in to GHCR`) surface if the workflow lacks `packages:write` permissions.
+- Build regressions for any container will fail the corresponding `Build and push … image` step.
+- Incorrect Docker context changes can make `Compute image tags` succeed but break the push steps if the tags collide or are invalid.

--- a/docs/workflows/main-discussion-summary.md
+++ b/docs/workflows/main-discussion-summary.md
@@ -1,0 +1,27 @@
+# Main discussion summary workflow
+
+The **Main discussion summary** automation publishes release-note style updates to GitHub Discussions after commits land on `main`.
+
+## Triggers
+- Fires on `push` events to `main`.
+- May be invoked manually via `workflow_dispatch` for ad-hoc summaries.
+
+## Required secrets and variables
+- `secrets.CODEX_API_KEY` authenticates the Codex CLI setup inside the container job.
+- Repository variables configure output: `vars.CODEX_BASE_URL`, `vars.DOCS_DISCUSSION_CATEGORY_ID`, and optional `vars.DOCS_DISCUSSION_LABELS` / `vars.DOCS_DISCUSSION_TITLE_PREFIX`.
+- `secrets.GITHUB_TOKEN` powers the discussion creation and repository checkout.
+
+## Jobs and major steps
+### `summarize` job
+- Runs inside a `python:3.11-slim` container, installing Git and curl in `Install required packages`.
+- Installs the Codex CLI via `Setup Codex CLI` and checks out the repo history in `Check out repository`.
+- Establishes the commit window through `Determine commit range`; empty diffs skip later steps.
+- Generates markdown notes with `Run commit summary script`, uploads them using `Upload discussion markdown`, and posts them via `Create or update discussion`.
+
+## Expected artifacts
+- `Upload discussion markdown` stores `discussion.md` as `main-discussion-summary-<run id>` for later reference.
+
+## Common failure modes
+- Missing Codex credentials or base URL values trigger early failures in `Setup Codex CLI` or `Install required packages`.
+- Empty commit ranges lead `Determine commit range` to short-circuit the run (expected when no files changed).
+- Missing `DOCS_DISCUSSION_CATEGORY_ID` or insufficient permissions cause `Create or update discussion` to fail, preventing new discussion threads from being created.

--- a/docs/workflows/project-backlog-plan.md
+++ b/docs/workflows/project-backlog-plan.md
@@ -1,0 +1,28 @@
+# Project backlog plan workflow
+
+The **Project backlog plan** automation generates Codex planning output when new GitHub Project items enter the backlog state.
+
+## Triggers
+- Runs on `projects_v2_item` events for newly created or edited items.
+
+## Required secrets and variables
+- `secrets.PROJECTS_WORKFLOW_TOKEN` (optional) overrides `secrets.GITHUB_TOKEN` for project mutations.
+- `secrets.CODEX_API_KEY` is required by `Install Codex CLI`.
+- Repository variables used: `vars.CODEX_BASE_URL` and `vars.CODEX_CLI_VERSION`.
+
+## Jobs and major steps
+### `plan` job
+- Loads the project item via `Gather project item metadata`, which also decides whether the automation should continue (`Status == Backlog`).
+- Writes decoded payload details to disk in `Write backlog context` and prepares dependencies in `Set up Python` and `Install planning dependencies`.
+- Installs the Codex CLI in `Install Codex CLI` and executes the planner through `Generate Codex plan`.
+- Captures structured output via `Capture plan result`, commits changes with `Commit backlog plan`, and advances the item using `Move project item to Ready`.
+- Cleans up temporary files in `Clean up temporary files` after the run.
+
+## Expected artifacts
+- No workflow artifacts are uploaded; the automation commits `backlog/backlog.yaml` updates directly when plans are generated.
+
+## Common failure modes
+- Missing secrets (`PROJECTS_WORKFLOW_TOKEN` or `CODEX_API_KEY`) cause early exits in `Gather project item metadata` or `Install Codex CLI`.
+- Invalid backlog items (no Status field or plan context) make `Gather project item metadata` skip execution.
+- Codex service outages raise errors in `Generate Codex plan`, preventing commits and status transitions.
+- Git commit issues or branch protections can cause `Commit backlog plan` to fail, leaving the item in Backlog.

--- a/docs/workflows/project-done-discussion.md
+++ b/docs/workflows/project-done-discussion.md
@@ -1,0 +1,24 @@
+# Project done discussion workflow
+
+The **Project done discussion** workflow opens a GitHub Discussion summarizing finished project items.
+
+## Triggers
+- Responds to `projects_v2_item` events whenever an item is edited or converted.
+
+## Required secrets and variables
+- `secrets.GITHUB_TOKEN` must permit discussion creation.
+- Repository variables configure output: `vars.PROJECT_DONE_DISCUSSION_CATEGORY_ID`, optional `vars.PROJECT_DONE_DISCUSSION_TITLE_PREFIX`, `vars.PROJECT_DONE_DISCUSSION_LABELS`, and field name overrides (`vars.PROJECT_STATUS_FIELD_NAMES`, `vars.PROJECT_DONE_STATUS_VALUE`, etc.).
+
+## Jobs and major steps
+### `post-discussion` job
+- Parses the project item context inside `Post discussion`, loading field values and ensuring the status matches the configured Done value.
+- Builds discussion content from the backlog link, Codex plan/run references, related PRs, and metadata discovered in the GraphQL query.
+- Creates the discussion via `createDiscussion` and adds labels when requested.
+
+## Expected artifacts
+- The workflow does not upload artifacts; the resulting GitHub Discussion is the primary output.
+
+## Common failure modes
+- Missing `PROJECT_DONE_DISCUSSION_CATEGORY_ID` halts the run inside `Post discussion`.
+- Items that have not reached the Done status cause the step to exit early without posting.
+- If the backlog, plan, or run fields referenced in the configuration are absent, the workflow produces incomplete context or exits when required data is missing.

--- a/docs/workflows/project-ready-execute.md
+++ b/docs/workflows/project-ready-execute.md
@@ -1,0 +1,31 @@
+# Project Ready Execute workflow
+
+The **Project Ready Execute** automation executes Codex Cloud plans once a backlog item transitions into the Ready state.
+
+## Triggers
+- Listens for `projects_v2_item` edits and runs when the Status field changes from Backlog to Ready.
+
+## Required secrets and variables
+- `secrets.CODEX_API_KEY` is required by `Ensure Codex configuration is available` and the Codex execution request.
+- Repository variables read in the job: `vars.CODEX_BASE_URL` and optional `vars.PROJECT_READY_REVIEWERS`/`vars.REVIEW_TEAM` for notifications.
+
+## Jobs and major steps
+### `prepare` job
+- Validates the event payload in `Validate event and gather item metadata`, ensuring the item moved from Backlog to Ready and that the `Codex Cloud Plan` field is populated.
+- Outputs the encoded plan and metadata for the next job, including reviewer hints and automation status field identifiers.
+
+### `execute` job
+- Verifies required configuration in `Ensure Codex configuration is available` and materializes the plan through `Decode Codex Cloud plan`.
+- Calls the Codex Cloud API in `Execute Codex Cloud plan`, capturing response JSON and logs.
+- Uploads run details as artifacts via `Upload Codex execution artifacts`.
+- Updates project fields and progress in `Update project item status`, and posts follow-up notes with `Post summary note`.
+- Writes a run summary block to the Actions UI in `Write job summary`.
+
+## Expected artifacts
+- `Upload Codex execution artifacts` publishes the plan, a pretty-printed copy, the API response, and a log bundle under `project-ready-<run id>`.
+
+## Common failure modes
+- Missing Codex credentials trigger an early exit in `Ensure Codex configuration is available`.
+- Invalid or blank plan payloads raise failures during `Validate event and gather item metadata` or `Decode Codex Cloud plan`.
+- HTTP errors from Codex cause `Execute Codex Cloud plan` to fail and block the status update.
+- GraphQL permission issues or schema drift can break `Update project item status`, leaving the item in Ready without reviewer reassignment.

--- a/docs/workflows/publish-containers.md
+++ b/docs/workflows/publish-containers.md
@@ -1,0 +1,34 @@
+# Publish Containers workflow
+
+The **Publish Containers** GitHub Actions workflow keeps the Docker images and compose manifest in sync with `main`, `live`, and tagged releases.
+
+## Triggers
+- `workflow_dispatch` with an optional `release_tag` input for ad-hoc promotions.
+- Weekly scheduled run at 12:00 UTC on Mondays.
+- `push` events targeting the `main` and `live` branches or tags matching `v*`.
+
+## Required secrets and variables
+- `secrets.GITHUB_TOKEN` is used by `Log in to GHCR`, `Upload compose manifest artifact`, and `Attach compose file to release` for registry and release access.
+- No additional repository variables are required; tags are derived from the workflow context or the optional dispatch input.
+
+## Jobs and major steps
+### `tests` job
+- Checks out the repository via `actions/checkout@v4`.
+- Installs the frontend toolchain in `Set up pnpm`, `Set up Node.js`, and `Enable corepack` before running `Install frontend dependencies`.
+- Runs the React test and build suites in `Frontend tests` and executes UI smoke coverage with `Playwright smoke tests`.
+- Provisions Python in `Set up Python`, installs dependencies through `Install backend dependencies`, and executes API checks with `Backend tests`.
+
+### `publish` job
+- Normalizes the target registry name in `Lowercase image repository` and prepares QEMU/Buildx for multi-arch builds.
+- Authenticates via `Log in to GHCR` and calculates version tags in `Compute image tags`.
+- Builds and pushes the backend, frontend, and scraper images using the respective `Build and push … image` steps.
+- Regenerates the docker compose manifest in `Generate compose manifest`, stores it via `Upload compose manifest artifact`, and attaches it to tagged releases with `Attach compose file to release`.
+
+## Expected artifacts
+- `Upload compose manifest artifact` publishes `docker-compose.generated.yml` for downstream deployment tooling.
+
+## Common failure modes
+- Test suites failing in `Frontend tests`, `Playwright smoke tests`, or `Backend tests` block the publish job because `publish` depends on `tests`.
+- Registry authentication issues (`Log in to GHCR`) or insufficient permissions will prevent pushes and cause the build steps to fail.
+- Missing or malformed `release_tag` inputs can surface in `Compute image tags`, yielding invalid tag sets and build failures.
+- Changes that break compose generation cause `Generate compose manifest` to fail, preventing the artifact upload and release attachment steps.


### PR DESCRIPTION
## Summary
- add documentation pages under docs/workflows/ for the publish, live image, and project automations
- link existing deployment, backlog, README, contributing, and changelog docs to the new workflow references

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68f2ee8bb9fc8323b11814e5ee693ce6