### PR TITLE
Harmonize project workflows on a shared projects token

### DIFF
--- a/.github/workflows/project-backlog-plan.yml
+++ b/.github/workflows/project-backlog-plan.yml
@@ -14,12 +14,14 @@ permissions:
 jobs:
   plan:
     runs-on: ubuntu-latest
+    env:
+      PROJECTS_TOKEN: ${{ secrets.PROJECTS_WORKFLOW_TOKEN != '' && secrets.PROJECTS_WORKFLOW_TOKEN || secrets.GITHUB_TOKEN }}
     steps:
       - name: Gather project item metadata
         id: metadata
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.PROJECTS_WORKFLOW_TOKEN != '' && secrets.PROJECTS_WORKFLOW_TOKEN || secrets.GITHUB_TOKEN }}
+          github-token: ${{ env.PROJECTS_TOKEN }}
           script: |
             const item = context.payload.projects_v2_item;
             if (!item) {
@@ -335,7 +337,7 @@ jobs:
         if: steps.metadata.outputs.run == 'true' && steps.plan_result.outputs.skipped != 'true'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.PROJECTS_WORKFLOW_TOKEN != '' && secrets.PROJECTS_WORKFLOW_TOKEN || secrets.GITHUB_TOKEN }}
+          github-token: ${{ env.PROJECTS_TOKEN }}
           script: |
             const projectId = '${{ steps.metadata.outputs.project_id }}';
             const itemId = '${{ steps.metadata.outputs.project_item_node_id }}';

--- a/.github/workflows/project-done-discussion.yml
+++ b/.github/workflows/project-done-discussion.yml
@@ -18,6 +18,7 @@ jobs:
     name: Create completion discussion
     runs-on: ubuntu-latest
     env:
+      PROJECTS_TOKEN: ${{ secrets.PROJECTS_WORKFLOW_TOKEN != '' && secrets.PROJECTS_WORKFLOW_TOKEN || secrets.GITHUB_TOKEN }}
       DISCUSSION_CATEGORY_ID: ${{ vars.PROJECT_DONE_DISCUSSION_CATEGORY_ID }}
       DISCUSSION_TITLE_PREFIX: ${{ vars.PROJECT_DONE_DISCUSSION_TITLE_PREFIX }}
       DISCUSSION_LABELS: ${{ vars.PROJECT_DONE_DISCUSSION_LABELS }}
@@ -31,7 +32,7 @@ jobs:
       - name: Post discussion
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ env.PROJECTS_TOKEN }}
           script: |
             const core = require('@actions/core');
 

--- a/.github/workflows/project-ready-execute.yml
+++ b/.github/workflows/project-ready-execute.yml
@@ -15,6 +15,8 @@ jobs:
   prepare:
     name: Prepare project item context
     runs-on: ubuntu-latest
+    env:
+      PROJECTS_TOKEN: ${{ secrets.PROJECTS_WORKFLOW_TOKEN != '' && secrets.PROJECTS_WORKFLOW_TOKEN || secrets.GITHUB_TOKEN }}
     outputs:
       should_run: ${{ steps.inspect.outputs.should_run }}
       item_id: ${{ steps.inspect.outputs.item_id }}
@@ -35,6 +37,7 @@ jobs:
         id: inspect
         uses: actions/github-script@v7
         with:
+          github-token: ${{ env.PROJECTS_TOKEN }}
           script: |
             const action = context.payload.action;
             const change = context.payload.changes?.field_value;
@@ -212,6 +215,7 @@ jobs:
     if: needs.prepare.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     env:
+      PROJECTS_TOKEN: ${{ secrets.PROJECTS_WORKFLOW_TOKEN != '' && secrets.PROJECTS_WORKFLOW_TOKEN || secrets.GITHUB_TOKEN }}
       PLAN_B64: ${{ needs.prepare.outputs.plan_b64 }}
       CODEX_API_KEY: ${{ secrets.CODEX_API_KEY }}
       CODEX_BASE_URL: ${{ vars.CODEX_BASE_URL }}
@@ -323,6 +327,7 @@ jobs:
           HTTP_CODE: ${{ steps.codex_run.outputs.http_code }}
           PLAN_PREVIEW: ${{ needs.prepare.outputs.plan_preview }}
         with:
+          github-token: ${{ env.PROJECTS_TOKEN }}
           script: |
             const projectId = process.env.PROJECT_ID;
             const itemId = process.env.ITEM_ID;
@@ -396,6 +401,7 @@ jobs:
           SUMMARY_LINE: ${{ steps.update_item.outputs.summary_line }}
           REVIEWERS_TO_NOTIFY: ${{ env.REVIEWERS_TO_NOTIFY }}
         with:
+          github-token: ${{ env.PROJECTS_TOKEN }}
           script: |
             const contentType = process.env.CONTENT_TYPE;
             const contentNumber = process.env.CONTENT_NUMBER ? parseInt(process.env.CONTENT_NUMBER, 10) : undefined;


### PR DESCRIPTION
## Summary
- add a shared PROJECTS_TOKEN environment variable to each Projects automation workflow
- route every GitHub Script step that touches Projects data through the shared token fallback

## Testing
- actionlint .github/workflows/project-backlog-plan.yml .github/workflows/project-ready-execute.yml .github/workflows/project-done-discussion.yml .github/workflows/main-discussion-summary.yml

------
https://chatgpt.com/codex/tasks/task_e_68f2ee7fc950832383073345645d65e2