### PR TITLE
Reorder checkout in discussion summary workflow

### DIFF
--- a/.github/workflows/main-discussion-summary.yml
+++ b/.github/workflows/main-discussion-summary.yml
@@ -30,16 +30,16 @@ jobs:
           apt-get install -y --no-install-recommends git curl
           rm -rf /var/lib/apt/lists/*
 
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Setup Codex CLI
         uses: ./.github/actions/setup-codex
         with:
           api-key: ${{ secrets.CODEX_API_KEY }}
           base-url: ${{ vars.CODEX_BASE_URL }}
-
-      - name: Check out repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Determine commit range
         id: range


### PR DESCRIPTION
## Summary
- move the repository checkout step before the Codex setup step in the summarize job of the main discussion summary workflow

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f2f7d6d9b4832397dc3a470b195a27