### PR TITLE
Refactor local bootstrap to Python module

### DIFF
--- a/scripts/bootstrap/__init__.py
+++ b/scripts/bootstrap/__init__.py
@@ -1,0 +1,7 @@
+"""Bootstrap helpers for vTOC automation scripts."""
+
+from __future__ import annotations
+
+__all__ = [
+    "local",
+]

--- a/scripts/bootstrap/local.py
+++ b/scripts/bootstrap/local.py
@@ -1,0 +1,371 @@
+"""Local bootstrap utilities for generating development artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, Mapping, MutableMapping, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+DEFAULT_CONFIG_JSON = {
+    "projectName": "vtoc",
+    "services": {
+        "traefik": False,
+        "postgres": True,
+        "n8n": False,
+        "wazuh": False,
+    },
+}
+
+JsonDict = Dict[str, Any]
+Emitter = Callable[[str, Mapping[str, Any]], None]
+
+
+class BootstrapError(RuntimeError):
+    """Raised when the bootstrap workflow cannot continue."""
+
+    def __init__(self, message: str, *, exit_code: int = 1) -> None:
+        super().__init__(message)
+        self.exit_code = exit_code
+
+
+def emit(event: str, payload: Mapping[str, Any]) -> None:
+    """Emit a structured log payload for downstream tooling."""
+
+    frame: Dict[str, Any] = {"event": event, **payload}
+    print(json.dumps(frame, sort_keys=True))
+
+
+def parse_config_payload(raw: str | None, *, emitter: Emitter) -> JsonDict:
+    raw = (raw or "").strip()
+    if not raw:
+        emitter("vtoc.local.config", {"status": "default"})
+        return json.loads(json.dumps(DEFAULT_CONFIG_JSON))
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+        emitter(
+            "vtoc.local.config",
+            {
+                "status": "error",
+                "error": f"Invalid configuration JSON: {exc}",
+            },
+        )
+        raise BootstrapError("Unable to parse configuration JSON") from exc
+
+    emitter("vtoc.local.config", {"status": "loaded"})
+    return data
+
+
+def _normalize_bundle(bundle: JsonDict) -> JsonDict:
+    if "value" in bundle and isinstance(bundle["value"], dict):
+        return bundle["value"]
+    return bundle
+
+
+@dataclass
+class BundleSelection:
+    bundle: JsonDict
+    source: str
+
+
+def fetch_terraform_bundle(
+    terraform_dir: Path,
+    *,
+    emitter: Emitter,
+) -> Tuple[JsonDict | None, str | None]:
+    terraform_bin = shutil.which("terraform")
+    if terraform_bin is None:
+        emitter(
+            "vtoc.local.terraform",
+            {"status": "unavailable", "reason": "not_found"},
+        )
+        return None, "not_found"
+
+    init_cmd = [terraform_bin, "-chdir", str(terraform_dir), "init", "-input=false"]
+    emitter(
+        "vtoc.local.terraform",
+        {"status": "init", "command": init_cmd},
+    )
+    init_result = subprocess.run(
+        init_cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if init_result.returncode != 0:
+        emitter(
+            "vtoc.local.terraform",
+            {
+                "status": "error",
+                "reason": "init_failed",
+                "returncode": init_result.returncode,
+                "stderr": init_result.stderr.strip(),
+            },
+        )
+        return None, "init_failed"
+
+    output_cmd = [
+        terraform_bin,
+        "-chdir",
+        str(terraform_dir),
+        "output",
+        "-json",
+        "config_bundle",
+    ]
+    emitter(
+        "vtoc.local.terraform",
+        {"status": "output", "command": output_cmd},
+    )
+    output_result = subprocess.run(
+        output_cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if output_result.returncode != 0:
+        emitter(
+            "vtoc.local.terraform",
+            {
+                "status": "error",
+                "reason": "output_failed",
+                "returncode": output_result.returncode,
+                "stderr": output_result.stderr.strip(),
+            },
+        )
+        return None, "output_failed"
+
+    try:
+        bundle_raw = json.loads(output_result.stdout)
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+        emitter(
+            "vtoc.local.terraform",
+            {
+                "status": "error",
+                "reason": "decode_failed",
+                "stderr": output_result.stdout.strip(),
+            },
+        )
+        return None, "decode_failed"
+
+    bundle = _normalize_bundle(bundle_raw)
+    emitter("vtoc.local.terraform", {"status": "success"})
+    return bundle, None
+
+
+def read_fallback_bundle(path: Path, *, emitter: Emitter) -> JsonDict:
+    if not path.exists():
+        emitter(
+            "vtoc.local.fallback",
+            {"status": "error", "reason": "missing", "path": str(path)},
+        )
+        raise BootstrapError(f"Fallback bundle missing at {path}")
+
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+        emitter(
+            "vtoc.local.fallback",
+            {
+                "status": "error",
+                "reason": "decode_failed",
+                "path": str(path),
+            },
+        )
+        raise BootstrapError(f"Fallback bundle at {path} is not valid JSON") from exc
+    emitter("vtoc.local.fallback", {"status": "loaded", "path": str(path)})
+    return data
+
+
+def resolve_config_bundle(
+    config: JsonDict,
+    terraform_dir: Path,
+    fallback_path: Path,
+    *,
+    emitter: Emitter,
+) -> BundleSelection:
+    override = config.get("configBundle")
+    if override is not None:
+        emitter("vtoc.local.bundle", {"status": "selected", "source": "override"})
+        if isinstance(override, str):
+            try:
+                override = json.loads(override)
+            except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+                raise BootstrapError("configBundle override is not valid JSON") from exc
+        if not isinstance(override, Mapping):
+            raise BootstrapError("configBundle override must be a mapping")
+        return BundleSelection(bundle=_normalize_bundle(override), source="override")
+
+    bundle, failure_reason = fetch_terraform_bundle(terraform_dir, emitter=emitter)
+    if bundle is not None:
+        emitter("vtoc.local.bundle", {"status": "selected", "source": "terraform"})
+        return BundleSelection(bundle=bundle, source="terraform")
+
+    emitter(
+        "vtoc.local.bundle",
+        {"status": "fallback", "reason": failure_reason},
+    )
+    fallback_bundle = read_fallback_bundle(fallback_path, emitter=emitter)
+    if not isinstance(fallback_bundle, Mapping):  # pragma: no cover - defensive
+        raise BootstrapError("Fallback bundle payload must be a mapping")
+    return BundleSelection(bundle=_normalize_bundle(fallback_bundle), source="fallback")
+
+
+def render_env_lines(env: Mapping[str, Any]) -> str:
+    pairs = []
+    for key in sorted(env):
+        value = env[key]
+        pairs.append(f"{key}={value}")
+    return "\n".join(pairs) + "\n"
+
+
+def ensure_executable(name: str) -> None:
+    if shutil.which(name) is None:
+        raise BootstrapError(f"Required executable '{name}' not found on PATH")
+
+
+def run_command(
+    command: Iterable[str],
+    *,
+    cwd: Path,
+    emitter: Emitter,
+    event: str,
+) -> None:
+    command_list = [str(arg) for arg in command]
+    emitter(event, {"status": "running", "command": command_list, "cwd": str(cwd)})
+    try:
+        subprocess.run(command_list, cwd=cwd, check=True)
+    except subprocess.CalledProcessError as exc:  # pragma: no cover - passthrough
+        emitter(
+            event,
+            {
+                "status": "error",
+                "returncode": exc.returncode,
+            },
+        )
+        raise BootstrapError(f"Command failed: {' '.join(command_list)}") from exc
+    emitter(event, {"status": "success"})
+
+
+def _determine_config_source(args: argparse.Namespace) -> str | None:
+    if args.config_json:
+        return args.config_json
+    if args.config:
+        return Path(args.config).read_text()
+    return os.environ.get("VTOC_CONFIG_JSON")
+
+
+def build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Bootstrap local vTOC resources")
+    parser.add_argument("--config-json", help="Inline JSON configuration payload")
+    parser.add_argument("--config", help="Path to JSON configuration file")
+    parser.add_argument(
+        "--terraform-dir",
+        type=Path,
+        default=REPO_ROOT / "infrastructure" / "terraform",
+        help="Directory containing Terraform configuration",
+    )
+    parser.add_argument(
+        "--fallback-bundle",
+        type=Path,
+        default=REPO_ROOT / "scripts" / "defaults" / "config_bundle.local.json",
+        help="Path to fallback configuration bundle",
+    )
+    parser.add_argument(
+        "--frontend-dir",
+        type=Path,
+        default=REPO_ROOT / "frontend",
+        help="Directory where the frontend project resides",
+    )
+    parser.add_argument(
+        "--skip-build",
+        action="store_true",
+        help="Skip pnpm install/build steps (primarily for testing)",
+    )
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = build_argument_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    emitter: Emitter = lambda event, payload: emit(event, payload)
+
+    config_payload = _determine_config_source(args)
+    config = parse_config_payload(config_payload, emitter=emitter)
+
+    try:
+        ensure_executable("pnpm")
+    except BootstrapError as exc:
+        emitter("vtoc.local.complete", {"status": "error", "error": str(exc)})
+        return exc.exit_code
+
+    selection: BundleSelection | None = None
+
+    try:
+        selection = resolve_config_bundle(
+            config,
+            args.terraform_dir,
+            args.fallback_bundle,
+            emitter=emitter,
+        )
+
+        frontend_env = selection.bundle.get("frontend", {}).get("env")
+        if not isinstance(frontend_env, MutableMapping):
+            raise BootstrapError("Frontend environment mapping missing from config bundle")
+
+        frontend_dir = args.frontend_dir
+        env_file = frontend_dir / ".env.local"
+        env_file.parent.mkdir(parents=True, exist_ok=True)
+        env_contents = render_env_lines(frontend_env)
+        env_file.write_text(env_contents)
+        emitter(
+            "vtoc.local.env_file",
+            {"status": "written", "path": str(env_file)},
+        )
+
+        if not args.skip_build:
+            run_command(
+                ["pnpm", "install", "--frozen-lockfile"],
+                cwd=frontend_dir,
+                emitter=emitter,
+                event="vtoc.local.pnpm.install",
+            )
+            run_command(
+                ["pnpm", "build"],
+                cwd=frontend_dir,
+                emitter=emitter,
+                event="vtoc.local.pnpm.build",
+            )
+
+    except BootstrapError as exc:
+        source = selection.source if selection is not None else "unknown"
+        emitter(
+            "vtoc.local.complete",
+            {
+                "status": "error",
+                "error": str(exc),
+                "bundleSource": source,
+            },
+        )
+        return exc.exit_code
+
+    emitter(
+        "vtoc.local.complete",
+        {"status": "success", "bundleSource": selection.source},
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    sys.exit(main())

--- a/scripts/bootstrap_cli.py
+++ b/scripts/bootstrap_cli.py
@@ -7,11 +7,15 @@ to the existing shell scripts or runs the equivalent commands directly.
 from __future__ import annotations
 
 import argparse
+import json
+import os
 import shlex
 import subprocess
 import sys
 from pathlib import Path
-from typing import Sequence
+from typing import Mapping, Sequence
+
+from scripts.bootstrap.local import DEFAULT_CONFIG_JSON
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SCRIPTS_DIR = REPO_ROOT / "scripts"
@@ -28,15 +32,37 @@ def _echo_command(command: Sequence[str]) -> None:
     print(f"$ {quoted}")
 
 
-def run_command(command: Sequence[str], *, cwd: Path | None = None) -> None:
+def run_command(
+    command: Sequence[str],
+    *,
+    cwd: Path | None = None,
+    env: Mapping[str, str] | None = None,
+) -> None:
     """Run *command* and exit with the same status on failure."""
 
     command = [str(arg) for arg in command]
     _echo_command(command)
+    merged_env = None
+    if env is not None:
+        merged_env = os.environ.copy()
+        merged_env.update(env)
     try:
-        subprocess.run(command, cwd=cwd, check=True)
+        subprocess.run(command, cwd=cwd, check=True, env=merged_env)
     except subprocess.CalledProcessError as exc:  # pragma: no cover - passthrough
         raise SystemExit(exc.returncode) from exc
+
+
+def load_config_payload(args: argparse.Namespace) -> str:
+    if args.config_json:
+        return args.config_json
+    if args.config:
+        if not args.config.exists():
+            raise SystemExit(f"Configuration file not found: {args.config}")
+        return args.config.read_text()
+    env_payload = os.environ.get("VTOC_CONFIG_JSON")
+    if env_payload:
+        return env_payload
+    return json.dumps(DEFAULT_CONFIG_JSON)
 
 
 def run_setup(
@@ -71,6 +97,12 @@ def run_setup(
 
 
 def setup_command_factory(mode: str):
+    if mode == "local":
+        def command(args: argparse.Namespace) -> None:
+            run_local_bootstrap(args)
+
+        return command
+
     def command(args: argparse.Namespace) -> None:
         run_setup(
             mode,
@@ -81,6 +113,20 @@ def setup_command_factory(mode: str):
         )
 
     return command
+
+
+def run_local_bootstrap(args: argparse.Namespace) -> None:
+    payload = load_config_payload(args)
+    env = os.environ.copy()
+    env["VTOC_CONFIG_JSON"] = payload
+    command = [
+        PYTHON,
+        "-m",
+        "scripts.bootstrap.local",
+        "--terraform-dir",
+        str(REPO_ROOT / "infrastructure" / "terraform"),
+    ]
+    run_command(command, env=env)
 
 
 def add_setup_options(parser: argparse.ArgumentParser) -> None:

--- a/scripts/setup_local.sh
+++ b/scripts/setup_local.sh
@@ -6,49 +6,18 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/prereqs.sh"
 
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-TERRAFORM_DIR="$ROOT_DIR/infrastructure/terraform"
-CONFIG_JSON="${VTOC_CONFIG_JSON:-{}}"
+CONFIG_JSON="${VTOC_CONFIG_JSON:-}" 
 
 check_prereqs \
-  "pnpm|8.6.0|https://pnpm.io/installation" \
-  "terraform|1.5.0|https://developer.hashicorp.com/terraform/downloads"
-
-printf 'Running local setup with configuration: %s\n' "$CONFIG_JSON"
+  "pnpm|8.6.0|https://pnpm.io/installation"
 
 if command -v codex >/dev/null 2>&1; then
   codex note "Executing local mode setup"
 fi
 
-terraform -chdir="$TERRAFORM_DIR" init -input=false >/dev/null
+args=("--terraform-dir" "$ROOT_DIR/infrastructure/terraform")
+if [[ -n "$CONFIG_JSON" ]]; then
+  args+=("--config-json" "$CONFIG_JSON")
+fi
 
-export ROOT_DIR TERRAFORM_DIR
-
-python - <<'PY'
-import subprocess
-from pathlib import Path
-import os
-import sys
-
-root_dir = Path(os.environ["ROOT_DIR"])
-terraform_dir = Path(os.environ["TERRAFORM_DIR"])
-
-try:
-    frontend_env = subprocess.check_output(
-        ["terraform", "-chdir", str(terraform_dir), "output", "-raw", "frontend_env_file"],
-        text=True,
-    )
-except subprocess.CalledProcessError as exc:
-    print(
-        "Failed to read Terraform outputs. Run `terraform apply` in infrastructure/terraform to populate state.",
-        file=sys.stderr,
-    )
-    raise SystemExit(exc.returncode) from exc
-
-frontend_dir = root_dir / "frontend"
-(frontend_dir / ".env.local").write_text(frontend_env)
-PY
-
-(cd "$ROOT_DIR/frontend" && pnpm install --frozen-lockfile)
-(cd "$ROOT_DIR/frontend" && pnpm build)
-
-printf 'Local mode complete. Start the dev server with "pnpm --dir frontend dev".\n'
+python -m scripts.bootstrap.local "${args[@]}"

--- a/scripts/tests/__init__.py
+++ b/scripts/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite for scripts utilities."""

--- a/scripts/tests/test_local_bootstrap.py
+++ b/scripts/tests/test_local_bootstrap.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.bootstrap import local
+
+
+def _noop_emitter(event: str, payload: dict[str, object]) -> None:
+    pass
+
+
+def test_resolve_config_bundle_uses_fallback_when_terraform_unavailable(monkeypatch, tmp_path: Path) -> None:
+    fallback_bundle = {
+        "frontend": {
+            "env": {
+                "FOO": "BAR",
+            }
+        }
+    }
+    fallback_path = tmp_path / "config_bundle.json"
+    fallback_path.write_text(json.dumps(fallback_bundle))
+
+    def fake_fetch(terraform_dir: Path, *, emitter: local.Emitter):
+        return None, "not_found"
+
+    monkeypatch.setattr(local, "fetch_terraform_bundle", fake_fetch)
+
+    selection = local.resolve_config_bundle(
+        config={},
+        terraform_dir=tmp_path / "terraform",
+        fallback_path=fallback_path,
+        emitter=_noop_emitter,
+    )
+
+    assert selection.source == "fallback"
+    assert selection.bundle["frontend"]["env"]["FOO"] == "BAR"


### PR DESCRIPTION
## Summary
- add a Python local bootstrap module that mirrors the container bundle selection logic and emits structured status logs
- point setup_local.sh and the bootstrap CLI at the new module so Terraform is optional for the local flow
- cover the Terraform-missing fallback path with a regression test under scripts/tests

## Testing
- pytest scripts/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68f3d1dc5d988323b658e0b91887e2fb