### PR TITLE
Add schema validation for setup configuration payloads

### DIFF
--- a/scripts/lib/config_validator.py
+++ b/scripts/lib/config_validator.py
@@ -1,0 +1,163 @@
+"""Minimal JSON schema validator for setup configuration."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, List, Sequence
+
+
+@dataclass
+class ValidationIssue:
+    """Represents a validation problem for a configuration payload."""
+
+    path: str
+    message: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {"path": self.path, "message": self.message}
+
+
+_TYPE_MAP = {
+    "object": dict,
+    "string": str,
+    "boolean": bool,
+}
+
+
+def _type_matches(instance: Any, expected: str) -> bool:
+    python_type = _TYPE_MAP.get(expected)
+    if python_type is None:
+        # Unknown type specifier; treat as a pass so that new schema types
+        # added in the future do not break validation unexpectedly.
+        return True
+    return isinstance(instance, python_type)
+
+
+def _format_path(path: Sequence[str]) -> str:
+    if not path:
+        return "$"
+    return "$." + ".".join(path)
+
+
+def _validate(instance: Any, schema: dict[str, Any], path: Sequence[str], issues: List[ValidationIssue]) -> None:
+    schema_type = schema.get("type")
+    if isinstance(schema_type, list):
+        if not any(_type_matches(instance, t) for t in schema_type):
+            issues.append(
+                ValidationIssue(
+                    path=_format_path(path),
+                    message=f"Expected value to match one of types {schema_type}, got {type(instance).__name__}",
+                )
+            )
+            return
+    elif isinstance(schema_type, str):
+        if not _type_matches(instance, schema_type):
+            issues.append(
+                ValidationIssue(
+                    path=_format_path(path),
+                    message=f"Expected type {schema_type}, got {type(instance).__name__}",
+                )
+            )
+            return
+
+    enum_values = schema.get("enum")
+    if enum_values is not None and instance not in enum_values:
+        issues.append(
+            ValidationIssue(
+                path=_format_path(path),
+                message=f"Value {instance!r} is not one of the allowed options: {enum_values}",
+            )
+        )
+        return
+
+    if schema_type == "object" and isinstance(instance, dict):
+        properties: dict[str, Any] = schema.get("properties", {})
+        required: Iterable[str] = schema.get("required", [])
+
+        for required_key in required:
+            if required_key not in instance:
+                issues.append(
+                    ValidationIssue(
+                        path=_format_path([*path, required_key]),
+                        message="Missing required property",
+                    )
+                )
+
+        additional_allowed = schema.get("additionalProperties", True)
+        for key, value in instance.items():
+            next_path = [*path, key]
+            if key in properties:
+                _validate(value, properties[key], next_path, issues)
+            elif additional_allowed is False:
+                issues.append(
+                    ValidationIssue(
+                        path=_format_path(next_path),
+                        message="Unexpected property",
+                    )
+                )
+
+
+def validate(instance: Any, schema: dict[str, Any]) -> list[ValidationIssue]:
+    """Validate *instance* against *schema* and return any issues found."""
+
+    issues: list[ValidationIssue] = []
+    _validate(instance, schema, (), issues)
+    return issues
+
+
+def _load_json(data: str) -> Any:
+    try:
+        return json.loads(data)
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive path
+        raise ValueError(f"Invalid JSON payload: {exc.msg}") from exc
+
+
+def _load_schema(path: Path) -> dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    except FileNotFoundError as exc:  # pragma: no cover - defensive path
+        raise ValueError(f"Schema file not found: {path}") from exc
+
+
+def validate_text(config_text: str, schema_path: Path) -> list[ValidationIssue]:
+    schema = _load_schema(schema_path)
+    try:
+        instance = _load_json(config_text or "{}")
+    except ValueError as exc:
+        return [ValidationIssue(path="$", message=str(exc))]
+    return validate(instance, schema)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate setup configuration payloads")
+    parser.add_argument("schema", type=Path, help="Path to the JSON schema file")
+    parser.add_argument(
+        "--config",
+        type=Path,
+        help="Path to the JSON configuration file. If omitted, stdin is used.",
+    )
+    args = parser.parse_args()
+
+    if args.config is not None:
+        config_text = args.config.read_text(encoding="utf-8")
+    else:
+        config_text = sys.stdin.read()
+
+    try:
+        issues = validate_text(config_text, args.schema)
+    except ValueError as exc:
+        print(json.dumps({"path": "$", "message": str(exc)}), file=sys.stderr)
+        return 1
+    if issues:
+        for issue in issues:
+            print(json.dumps(issue.to_dict()), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -6,6 +6,7 @@ CONFIG_PATH=""
 CONFIG_JSON_ARG=""
 APPLY="false"
 CONFIGURE="false"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 usage() {
   cat <<USAGE
@@ -119,14 +120,24 @@ expand_with_codex() {
   fi
 }
 
+validate_config_payload() {
+  local json_input="$1"
+  if ! python "$SCRIPT_DIR/lib/config_validator.py" "$SCRIPT_DIR/inputs.schema.json" <<<"$json_input"; then
+    echo "Configuration validation failed." >&2
+    return 1
+  fi
+}
+
 CONFIG_JSON=$(load_config)
 CONFIG_JSON=$(expand_with_codex "$CONFIG_JSON")
+
+if ! validate_config_payload "$CONFIG_JSON"; then
+  exit 1
+fi
 
 export VTOC_CONFIG_JSON="$CONFIG_JSON"
 export VTOC_SETUP_APPLY="$APPLY"
 export VTOC_SETUP_CONFIGURE="$CONFIGURE"
-
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 MODE_SCRIPT="$SCRIPT_DIR/setup_${MODE}.sh"
 
 if [[ ! -x "$MODE_SCRIPT" ]]; then

--- a/scripts/tests/test_config_validator.py
+++ b/scripts/tests/test_config_validator.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from scripts.lib.config_validator import validate, validate_text
+
+SCHEMA_PATH = Path(__file__).resolve().parents[1] / "inputs.schema.json"
+
+
+def load_schema() -> dict:
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def test_valid_configuration_passes_validation():
+    schema = load_schema()
+    config = {
+        "projectName": "demo",
+        "services": {"postgres": True, "traefik": False},
+        "cloud": {"provider": "aws", "region": "us-west-2"},
+    }
+
+    issues = validate(config, schema)
+
+    assert issues == []
+
+
+def test_invalid_type_reports_issue():
+    schema = load_schema()
+    config = {"projectName": 123}
+
+    issues = validate(config, schema)
+
+    assert issues
+    assert issues[0].path == "$.projectName"
+    assert "Expected type string" in issues[0].message
+
+
+def test_unexpected_property_reports_issue():
+    schema = load_schema()
+    config = {"services": {"unknown": True}}
+
+    issues = validate(config, schema)
+
+    assert issues
+    assert issues[0].path == "$.services.unknown"
+    assert issues[0].message == "Unexpected property"
+
+
+def test_invalid_enum_reports_issue():
+    schema = load_schema()
+    config = {"cloud": {"provider": "digitalocean"}}
+
+    issues = validate(config, schema)
+
+    assert issues
+    assert issues[0].path == "$.cloud.provider"
+    assert "allowed options" in issues[0].message
+
+
+def test_invalid_json_reports_issue():
+    issues = validate_text("{invalid json", SCHEMA_PATH)
+
+    assert issues
+    assert issues[0].path == "$"
+    assert "Invalid JSON payload" in issues[0].message


### PR DESCRIPTION
## Summary
- add a minimal JSON-schema validator for setup configuration payloads
- validate `setup.sh` configs against the shared schema before running mode scripts
- add pytest coverage for valid and invalid configuration payloads

## Testing
- pytest scripts/tests

------
https://chatgpt.com/codex/tasks/task_e_68f3d1e557a083239ae14bc3353f8f9d