### PR TITLE
Automate prod-to-live promotions

### DIFF
--- a/.github/workflows/live-release-pr.yml
+++ b/.github/workflows/live-release-pr.yml
@@ -15,11 +15,11 @@ permissions:
 
 jobs:
   tests:
-    if: github.head_ref == 'stage'
+    if: github.head_ref == 'stage' || github.head_ref == 'prod'
     uses: ./.github/workflows/reusable-tests.yml
 
   publish:
-    if: github.head_ref == 'stage'
+    if: github.head_ref == 'stage' || github.head_ref == 'prod'
     needs: tests
     uses: ./.github/workflows/reusable-build-containers.yml
     secrets: inherit
@@ -29,7 +29,7 @@ jobs:
     needs:
       - tests
       - publish
-    if: github.head_ref == 'stage' && always()
+    if: (github.head_ref == 'stage' || github.head_ref == 'prod') && always()
     runs-on: ubuntu-latest
     steps:
       - name: Publish summary

--- a/.github/workflows/prod-to-live.yml
+++ b/.github/workflows/prod-to-live.yml
@@ -1,0 +1,152 @@
+name: Promote prod to live
+
+on:
+  push:
+    branches:
+      - prod
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+  checks: read
+  administration: write
+
+jobs:
+  promote:
+    name: Promote prod changes to live
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out prod branch
+        uses: actions/checkout@v4
+        with:
+          ref: prod
+
+      - name: Open promotion pull request
+        id: create_pr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: live
+          branch: prod
+          delete-branch: false
+          commit-message: "chore: promote prod to live"
+          title: "Promote prod to live"
+          body: |
+            ## Summary
+            - Automated promotion of the `prod` branch into `live` after a successful production deployment.
+
+            ## Notes
+            - Auto-merge will be enabled once required checks succeed.
+
+      - name: Enable auto-merge on promotion PR
+        if: steps.create_pr.outputs.pull-request-number
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = Number('${{ steps.create_pr.outputs.pull-request-number }}');
+            if (!prNumber) {
+              core.info('No pull request created or updated; skipping auto-merge configuration.');
+              return;
+            }
+
+            const { repository } = await github.graphql(
+              `query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    id
+                    autoMergeRequest {
+                      enabledAt
+                    }
+                  }
+                }
+              }`,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                number: prNumber,
+              }
+            );
+
+            const pullRequest = repository?.pullRequest;
+            if (!pullRequest?.id) {
+              core.setFailed(`Failed to resolve pull request ID for #${prNumber}.`);
+              return;
+            }
+
+            if (pullRequest.autoMergeRequest?.enabledAt) {
+              core.info(`Auto-merge is already enabled for pull request #${prNumber}.`);
+              return;
+            }
+
+            try {
+              await github.graphql(
+                `mutation($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {
+                  enablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId, mergeMethod: $mergeMethod }) {
+                    pullRequest {
+                      number
+                      autoMergeRequest {
+                        enabledAt
+                      }
+                    }
+                  }
+                }`,
+                {
+                  pullRequestId: pullRequest.id,
+                  mergeMethod: 'SQUASH',
+                }
+              );
+              core.info(`Auto-merge enabled for pull request #${prNumber}.`);
+            } catch (error) {
+              core.warning(`Failed to enable auto-merge for pull request #${prNumber}: ${error.message}`);
+            }
+
+      - name: Require live branch release checks
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const requiredChecks = [
+              'Live Release PR Gate / tests',
+              'Live Release PR Gate / publish',
+            ];
+
+            try {
+              await github.rest.repos.updateStatusCheckProtection({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                branch: 'live',
+                strict: true,
+                contexts: requiredChecks,
+              });
+              core.info('Updated required status checks for the live branch.');
+              return;
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+              core.info('Status check protection not yet configured; creating full branch protection rule.');
+            }
+
+            await github.rest.repos.updateBranchProtection({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              branch: 'live',
+              required_status_checks: {
+                strict: true,
+                contexts: requiredChecks,
+              },
+              enforce_admins: true,
+              required_pull_request_reviews: {
+                required_approving_review_count: 0,
+              },
+              restrictions: null,
+              allow_force_pushes: false,
+              allow_deletions: false,
+              required_linear_history: false,
+              lock_branch: false,
+              allow_fork_syncing: true,
+              block_creations: false,
+            });
+            core.info('Created branch protection for live with required status checks.');

--- a/docs/live/README.md
+++ b/docs/live/README.md
@@ -1,0 +1,18 @@
+# Live Branch Overview
+
+The `live` branch represents the actively running production environment that consumers interact with.
+
+## Terraform Cloud integration
+
+Infrastructure state and deployments are coordinated through Terraform Cloud. Promotion pull requests targeting `live` should have already passed through the Terraform Cloud pipelines while in `prod`, so merges simply confirm that the latest applied infrastructure matches the source of truth.
+
+## Fly deployment expectations
+
+Fly.io receives container images produced by the release gate workflow. Once a promotion pull request merges, Fly deploys the images referenced by the `live` branch. Operational readiness checks in Fly should be complete before approving manual overrides.
+
+## Automated promotion path
+
+1. Code merges into `prod` after passing its gating workflows.
+2. The `Promote prod to live` workflow opens or updates a pull request from `prod` to `live`, requests auto-merge, and enforces the release status checks.
+3. The `Live Release PR Gate` workflow runs tests and publishes containers using the `prod` branch head.
+4. GitHub automatically merges the promotion pull request once all required checks succeed, finalizing the promotion to `live`.

--- a/docs/workflows/prod-to-live.md
+++ b/docs/workflows/prod-to-live.md
@@ -1,0 +1,20 @@
+# Promote prod to live
+
+This workflow automatically promotes the `prod` branch into `live` after a push lands in production.
+
+## Trigger
+
+- **On push to `prod`** – any new commit pushed to the production branch starts the workflow.
+
+## What it does
+
+1. Checks out the current `prod` branch revision.
+2. Uses [`peter-evans/create-pull-request`](https://github.com/peter-evans/create-pull-request) to open or update a pull request targeting `live`.
+3. Enables auto-merge on the promotion pull request so it completes as soon as all required checks pass.
+4. Updates the `live` branch protection rule to require the release gate checks (tests and container publishing).
+
+## Why it matters
+
+- Keeps `live` synchronized with the hardened `prod` branch through a reviewable pull request.
+- Guarantees that the release gate workflow runs and passes before changes ship to `live`.
+- Avoids manual intervention by enabling auto-merge and ensuring branch protection enforces the necessary checks.


### PR DESCRIPTION
## Summary
- add a prod-to-live promotion workflow that opens PRs from prod, enables auto-merge, and enforces release status checks
- run the Live Release PR Gate workflow when the promotion PR head is prod
- document the promotion workflow and expectations for the live branch

## Testing
- not run (not required for workflow and documentation changes)


------
https://chatgpt.com/codex/tasks/task_e_68f3e6cbaee4832389e040696aa66893