### PR TITLE
Add prod verification guardrails for container publishing

### DIFF
--- a/.github/workflows/publish-containers.yml
+++ b/.github/workflows/publish-containers.yml
@@ -12,12 +12,14 @@ on:
     branches:
       - main
       - live
+      - prod
     tags:
       - 'v*'
 
 permissions:
   contents: write
   packages: write
+  issues: write
 
 jobs:
   tests:
@@ -27,14 +29,141 @@ jobs:
     needs: tests
     uses: ./.github/workflows/reusable-build-containers.yml
     with:
-      release_tag: ${{ github.event.inputs.release_tag }}
+      release_tag: ${{ github.ref == 'refs/heads/prod' ? 'prod' : github.event.inputs.release_tag }}
     secrets: inherit
+
+  verify-dockerhub:
+    name: Verify Docker Hub prod images
+    needs: publish
+    if: ${{ needs.publish.result == 'success' && github.ref == 'refs/heads/prod' }}
+    runs-on: ubuntu-latest
+    env:
+      DOCKERHUB_REGISTRY: docker.io
+      RELEASE_TAG: prod
+    steps:
+      - name: Prepare log directory
+        run: mkdir -p verify-logs
+
+      - name: Determine Docker Hub namespace
+        id: repo
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${DOCKERHUB_USERNAME:-}" ]]; then
+            echo "Docker Hub username secret must be provided" >&2
+            exit 1
+          fi
+          echo "dockerhub_namespace=$(echo "${DOCKERHUB_USERNAME}" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.DOCKERHUB_REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Pull prod images
+        env:
+          NAMESPACE: ${{ steps.repo.outputs.dockerhub_namespace }}
+        run: |
+          set -euo pipefail
+          for service in backend frontend scraper; do
+            docker pull "${DOCKERHUB_REGISTRY}/${NAMESPACE}/${service}:${RELEASE_TAG}"
+          done
+
+      - name: Backend smoke test
+        env:
+          IMAGE: ${{ env.DOCKERHUB_REGISTRY }}/${{ steps.repo.outputs.dockerhub_namespace }}/backend:${{ env.RELEASE_TAG }}
+        run: |
+          set -euo pipefail
+          docker run -d --name backend-smoke -p 18080:8080 "${IMAGE}"
+          attempts=0
+          until curl -fsS "http://127.0.0.1:18080/healthz" >/dev/null; do
+            attempts=$((attempts + 1))
+            if [[ ${attempts} -ge 10 ]]; then
+              echo "Backend health check failed" >&2
+              docker logs backend-smoke > verify-logs/backend.log || true
+              docker rm -f backend-smoke >/dev/null 2>&1 || true
+              exit 1
+            fi
+            sleep 3
+          done
+          docker rm -f backend-smoke >/dev/null 2>&1 || true
+
+      - name: Frontend smoke test
+        env:
+          IMAGE: ${{ env.DOCKERHUB_REGISTRY }}/${{ steps.repo.outputs.dockerhub_namespace }}/frontend:${{ env.RELEASE_TAG }}
+        run: |
+          set -euo pipefail
+          docker run -d --name frontend-smoke -p 18081:8081 "${IMAGE}"
+          attempts=0
+          until curl -fsS "http://127.0.0.1:18081/" >/dev/null; do
+            attempts=$((attempts + 1))
+            if [[ ${attempts} -ge 10 ]]; then
+              echo "Frontend health check failed" >&2
+              docker logs frontend-smoke > verify-logs/frontend.log || true
+              docker rm -f frontend-smoke >/dev/null 2>&1 || true
+              exit 1
+            fi
+            sleep 3
+          done
+          docker rm -f frontend-smoke >/dev/null 2>&1 || true
+
+      - name: Scraper smoke test
+        env:
+          IMAGE: ${{ env.DOCKERHUB_REGISTRY }}/${{ steps.repo.outputs.dockerhub_namespace }}/scraper:${{ env.RELEASE_TAG }}
+        run: |
+          set -euo pipefail
+          if ! docker run --name scraper-smoke --entrypoint python "${IMAGE}" -c "print('scraper image ready')"; then
+            echo "Scraper exit check failed" >&2
+            docker logs scraper-smoke > verify-logs/scraper.log || true
+            docker rm -f scraper-smoke >/dev/null 2>&1 || true
+            exit 1
+          fi
+          docker rm -f scraper-smoke >/dev/null 2>&1 || true
+
+      - name: Upload verification logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dockerhub-verification-logs
+          path: verify-logs
+          if-no-files-found: warn
+
+      - name: File verification failure issue
+        if: failure()
+        uses: actions/github-script@v7
+        env:
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const tag = process.env.RELEASE_TAG || 'prod';
+            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+            const title = `Prod Docker Hub verification failed (${tag})`;
+            const body = [
+              `Verification of Docker Hub images tagged \`${tag}\` failed.`,
+              '',
+              `- Workflow run: ${runUrl}`,
+              `- Trigger: ${context.eventName} on ${context.ref}`,
+              '',
+              'Review the attached verification logs for details.'
+            ].join('\n');
+            try {
+              await github.rest.issues.create({ owner, repo, title, body });
+            } catch (error) {
+              if (error.status !== 422) {
+                throw error;
+              }
+            }
 
   summary:
     name: Release pipeline summary
     needs:
       - tests
       - publish
+      - verify-dockerhub
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -44,6 +173,7 @@ jobs:
           PUBLISH_RESULT: ${{ needs.publish.result }}
           SCAN_STATUS: ${{ needs.publish.outputs.scan_status }}
           PUSH_STATUS: ${{ needs.publish.outputs.push_status }}
+          VERIFY_RESULT: ${{ needs.verify-dockerhub.result }}
         run: |
           tests_line="- ❌ Tests ${TESTS_RESULT}"
           if [[ "${TESTS_RESULT}" == "success" ]]; then
@@ -64,10 +194,18 @@ jobs:
               push_line="- ⚠️ Multi-arch image push status unavailable"
             fi
           fi
+          if [[ "${VERIFY_RESULT}" == "success" ]]; then
+            verify_line="- ✅ Docker Hub prod verification passed"
+          elif [[ "${VERIFY_RESULT}" == "skipped" ]]; then
+            verify_line="- ⚠️ Docker Hub verification skipped"
+          else
+            verify_line="- ❌ Docker Hub verification ${VERIFY_RESULT}"
+          fi
           {
             echo "## Release Pipeline Summary"
             echo
             echo "${tests_line}"
             echo "${scan_line}"
             echo "${push_line}"
+            echo "${verify_line}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/communications/prod-branch/README.md
+++ b/docs/communications/prod-branch/README.md
@@ -1,0 +1,33 @@
+# Prod branch operations
+
+This README documents how the `prod` branch coordinates deployments across the self-hosted (`main`) and managed cloud (`live`) environments while enforcing production verification guardrails.
+
+## Purpose of the `prod` branch
+
+* Acts as the umbrella release branch that consolidates changes proven in `main` (self-hosted operators) and `live` (Fly.io cloud).
+* Produces the long-lived `prod` image tag in both GHCR and Docker Hub so downstream automation can subscribe to a stable artifact.
+* Runs end-to-end verification of the published container images before sign-off, giving operators confidence that the multi-instance fleet is in sync.
+
+## Multi-instance orchestration
+
+1. Develop and test features on short-lived branches that merge into `main`. Self-hosted instances can continue to deploy directly from `main` once their validations pass.
+2. Promote the same changes into `live` via release branches to refresh the Fly.io environment. Confirm cloud-specific smoke tests succeed before proceeding.
+3. When both environments are ready, fast-forward or merge `prod` to the harmonized commit so that container publishing reflects the unified state.
+4. Allow the **Publish Containers** workflow to build the `prod` tag. The workflow regenerates the compose manifest, ensuring self-hosted clusters and cloud workers pull a consistent stack.
+
+## Verification guardrails
+
+The publish workflow adds a `verify-dockerhub` job that only runs on `prod`:
+
+* Pulls the freshly tagged `docker.io/<namespace>/<service>:prod` images produced earlier in the pipeline.
+* Boots disposable backend and frontend containers, curling `/healthz` and `/` respectively until they respond successfully.
+* Executes a scraper container command to verify the image exits cleanly.
+* Uploads container logs and opens a GitHub Issue pointing to the workflow run when any smoke test fails, ensuring the incident is tracked and triaged before images propagate.
+
+If the verification job fails, do **not** deploy the new images. Investigate the linked issue, remediate the root cause (code fix, configuration, or infrastructure), and rerun the workflow once resolved. On success, document the promotion in the same channels used for `main` and `live` releases so operators across both environments stay aligned.
+
+## Communication checklist
+
+* Announce `prod` promotions in the deployment discussion alongside the associated `main` and `live` updates.
+* Include links to the successful verification run and note any overrides applied for self-hosted versus cloud operators.
+* Capture follow-up tasks (for example, additional monitoring or rollback drills) if the verification pipeline surfaced new action items.

--- a/docs/workflows/publish-containers.md
+++ b/docs/workflows/publish-containers.md
@@ -1,11 +1,12 @@
 # Publish Containers workflow
 
-The **Publish Containers** GitHub Actions workflow keeps the Docker images and compose manifest in sync with `main`, `live`, and tagged releases.
+The **Publish Containers** GitHub Actions workflow keeps the Docker images and compose manifest in sync with `main`, `live`, `prod`, and tagged releases.
 
 ## Triggers
 - `workflow_dispatch` with an optional `release_tag` input for ad-hoc promotions.
 - Weekly scheduled run at 12:00 UTC on Mondays.
-- `push` events targeting the `main` and `live` branches or tags matching `v*`.
+- `push` events targeting the `main`, `live`, and `prod` branches or tags matching `v*`.
+- When the workflow runs on the `prod` branch, it automatically passes `prod` as the `release_tag` to keep a stable production alias in both registries.
 
 ## Required secrets and variables
 - `secrets.GITHUB_TOKEN` is used by `Log in to GHCR`, `Upload compose manifest artifact`, and `Attach compose file to release` for registry and release access.
@@ -24,11 +25,19 @@ The **Publish Containers** GitHub Actions workflow keeps the Docker images and c
 - Builds and pushes the backend, frontend, and scraper images using the respective `Build and push … image` steps.
 - Regenerates the docker compose manifest in `Generate compose manifest`, stores it via `Upload compose manifest artifact`, and attaches it to tagged releases with `Attach compose file to release`.
 
+### `verify-dockerhub` job
+- Runs only after a successful publish on the `prod` branch.
+- Pulls the `docker.io/<namespace>/<service>:prod` images emitted by the publish job and revalidates that they start correctly.
+- Launches disposable containers for the backend (`/healthz`) and frontend (`/`) to curl their health endpoints until they succeed, and performs an exit-status check for the scraper image.
+- Uploads container logs when a verification step fails and opens a GitHub Issue referencing the workflow run and prod tag via `actions/github-script` for rapid triage.
+
 ## Expected artifacts
 - `Upload compose manifest artifact` publishes `docker-compose.generated.yml` for downstream deployment tooling.
+- `dockerhub-verification-logs` (only on failures) captures the container logs gathered during production verification.
 
 ## Common failure modes
 - Test suites failing in `Frontend tests`, `Playwright smoke tests`, or `Backend tests` block the publish job because `publish` depends on `tests`.
 - Registry authentication issues (`Log in to GHCR`) or insufficient permissions will prevent pushes and cause the build steps to fail.
 - Missing or malformed `release_tag` inputs can surface in `Compute image tags`, yielding invalid tag sets and build failures.
 - Changes that break compose generation cause `Generate compose manifest` to fail, preventing the artifact upload and release attachment steps.
+- Production verification failures (for example, health checks timing out or missing Docker Hub credentials) trigger the `verify-dockerhub` job to upload logs and open a GitHub Issue for follow-up.


### PR DESCRIPTION
## Summary
- add the prod branch trigger to the publish workflow and force prod tagging when it runs
- add a Docker Hub verification job that smoke tests prod-tagged images and files an issue on failure
- document the new flow in the publish workflow guide and add a prod branch README for multi-instance deployments

## Testing
- not run (workflow and documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68f3e6cf60b48323afb08b1ed25e7a5c