### PR TITLE
Add Stage CI workflow and reporting automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,6 @@ permissions:
   packages: read
 
 on:
-  push:
-    branches: [live]
-  pull_request:
-    branches: [live]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/stage-ci-report.yml
+++ b/.github/workflows/stage-ci-report.yml
@@ -1,0 +1,110 @@
+name: Stage CI Report
+
+on:
+  workflow_run:
+    workflows: ["Stage CI"]
+    types:
+      - completed
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  actions: read
+
+jobs:
+  update-stage-readme:
+    name: Update stage README report
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update stage report table
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const workflowId = 'stage-ci.yml';
+            const perPage = 10;
+            const branch = 'stage';
+            const readmePath = 'README.md';
+            const startMarker = '<!-- stage-ci-report:start -->';
+            const endMarker = '<!-- stage-ci-report:end -->';
+
+            async function listRecentRuns(page = 1) {
+              const { data } = await github.rest.actions.listWorkflowRuns({
+                owner,
+                repo,
+                workflow_id: workflowId,
+                per_page: perPage,
+                page
+              });
+              return data.workflow_runs || [];
+            }
+
+            const runs = [];
+            for (let page = 1; page <= 2 && runs.length < perPage; page++) {
+              const pageRuns = await listRecentRuns(page);
+              if (!pageRuns.length) break;
+              runs.push(
+                ...pageRuns.filter((run) => run.head_branch === branch)
+              );
+            }
+
+            if (!runs.length) {
+              runs.push({
+                status: 'completed',
+                conclusion: 'none',
+                event: 'n/a',
+                html_url: 'https://github.com/' + owner + '/' + repo + '/actions',
+                head_sha: 'n/a',
+                updated_at: new Date().toISOString()
+              });
+            }
+
+            const tableRows = runs.slice(0, 5).map((run) => {
+              const finished = run.updated_at ? new Date(run.updated_at) : null;
+              const timestamp = finished ? finished.toISOString().replace('T', ' ').replace('Z', 'Z') : '—';
+              const shortSha = run.head_sha && run.head_sha !== 'n/a' ? run.head_sha.substring(0, 7) : 'n/a';
+              const conclusion = run.conclusion ? run.conclusion : (run.status || 'unknown');
+              return `| ${timestamp} | ${run.event} | ${conclusion} | [${shortSha}](${run.html_url}) |`;
+            }).join('\n');
+
+            const table = [
+              '| Completed (UTC) | Event | Result | Details |',
+              '| --- | --- | --- | --- |',
+              tableRows
+            ].join('\n');
+
+            const { data: currentContent } = await github.rest.repos.getContent({
+              owner,
+              repo,
+              path: readmePath,
+              ref: branch
+            });
+
+            const decoded = Buffer.from(currentContent.content, 'base64').toString();
+
+            if (!decoded.includes(startMarker) || !decoded.includes(endMarker)) {
+              throw new Error('Stage README markers are missing; ensure the stage CI report markers exist.');
+            }
+
+            const markerRegex = new RegExp(`${startMarker}[\s\S]*?${endMarker}`);
+            const updated = decoded.replace(markerRegex, `${startMarker}\n${table}\n${endMarker}`);
+
+            if (updated === decoded) {
+              core.info('No README changes required.');
+              return;
+            }
+
+            await github.rest.repos.createOrUpdateFileContents({
+              owner,
+              repo,
+              path: readmePath,
+              message: 'docs(stage): refresh Stage CI report',
+              content: Buffer.from(updated).toString('base64'),
+              branch,
+              sha: currentContent.sha
+            });
+            core.info('Stage README updated with latest Stage CI run metadata.');

--- a/.github/workflows/stage-ci.yml
+++ b/.github/workflows/stage-ci.yml
@@ -1,0 +1,70 @@
+name: Stage CI
+
+on:
+  push:
+    branches: [stage]
+  pull_request:
+    branches: [stage]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+  actions: read
+
+jobs:
+  tests:
+    name: Run reusable tests
+    uses: ./.github/workflows/reusable-tests.yml
+    secrets: inherit
+
+  build:
+    name: Build and publish stage containers
+    if: github.event_name == 'push'
+    needs: tests
+    uses: ./.github/workflows/reusable-build-containers.yml
+    with:
+      release_tag: stage
+    secrets: inherit
+
+  metadata:
+    name: Publish run metadata
+    runs-on: ubuntu-latest
+    needs:
+      - tests
+      - build
+    if: always()
+    outputs:
+      tests_status: ${{ steps.capture.outputs.tests_status }}
+      scan_status: ${{ steps.capture.outputs.scan_status }}
+      push_status: ${{ steps.capture.outputs.push_status }}
+    steps:
+      - name: Capture job results
+        id: capture
+        run: |
+          tests_status="${{ needs.tests.outputs.status }}"
+          if [ -z "$tests_status" ]; then
+            tests_status="unknown"
+          fi
+          scan_status="${{ needs.build.outputs.scan_status }}"
+          if [ -z "$scan_status" ]; then
+            scan_status="skipped"
+          fi
+          push_status="${{ needs.build.outputs.push_status }}"
+          if [ -z "$push_status" ]; then
+            push_status="skipped"
+          fi
+          {
+            echo "tests_status=$tests_status"
+            echo "scan_status=$scan_status"
+            echo "push_status=$push_status"
+          } >> "$GITHUB_OUTPUT"
+          cat <<REPORT >> "$GITHUB_STEP_SUMMARY"
+          ## Stage CI results
+
+          | Step | Status |
+          | --- | --- |
+          | Tests | $tests_status |
+          | Container scan | $scan_status |
+          | Container push | $push_status |
+          REPORT


### PR DESCRIPTION
## Summary
- add a Stage CI workflow that reuses the shared tests, builds tagged images, and publishes run metadata
- disable the live branch trigger in ci.yml to rely on the Stage pipeline and promotion gate
- schedule a Stage CI report workflow that records recent runs in the stage README and document the automation loop

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f3e6d3312483239921e39af5b9f5e0