### PR TITLE
Add codex-to-stage promotion workflow

### DIFF
--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -5,6 +5,7 @@ name: Codex PR review
   pull_request:
     branches:
       - codex
+      - stage
 
 permissions:
   contents: read
@@ -29,11 +30,13 @@ jobs:
           python-version: "3.11"
 
       - name: Install lint tooling
+        if: github.event.pull_request.base.ref != 'stage'
         run: |
           python -m pip install --upgrade pip
           pip install yamllint
 
       - name: Lint workflow files
+        if: github.event.pull_request.base.ref != 'stage'
         run: |
           yamllint .github/workflows
 

--- a/.github/workflows/codex-sync-stage.yml
+++ b/.github/workflows/codex-sync-stage.yml
@@ -1,0 +1,181 @@
+name: Codex sync to stage
+
+on:
+  push:
+    branches:
+      - codex
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  tests:
+    name: Validate codex branch
+    uses: ./.github/workflows/reusable-tests.yml
+    secrets: inherit
+
+  publish-status:
+    name: Record validation outcome
+    needs: tests
+    if: always()
+    runs-on: ubuntu-latest
+    outputs:
+      status: ${{ steps.capture.outputs.status }}
+    steps:
+      - id: capture
+        env:
+          TEST_RESULT: ${{ needs.tests.result }}
+          TEST_STATUS: ${{ needs.tests.outputs.status }}
+        run: |
+          status="${TEST_STATUS}"
+          if [ -z "$status" ]; then
+            status="$TEST_RESULT"
+          fi
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+      - name: Summarize validation
+        run: |
+          echo "## Codex validation" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Commit: $GITHUB_SHA" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Status: ${{ steps.capture.outputs.status }}" >> "$GITHUB_STEP_SUMMARY"
+
+  promote:
+    name: Promote codex to stage
+    needs:
+      - tests
+      - publish-status
+    if: needs.tests.result == 'success' && needs.tests.outputs.status == 'passed'
+    runs-on: ubuntu-latest
+    env:
+      STAGE_MAINTAINERS: ${{ vars.CODEX_STAGE_MAINTAINERS }}
+      AUTO_MERGE_LABEL: ${{ vars.CODEX_AUTO_MERGE_LABEL }}
+    steps:
+      - name: Note successful validation
+        run: |
+          echo "Validation succeeded for $GITHUB_SHA." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Ensure promotion pull request exists
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const head = 'codex';
+            const base = 'stage';
+            const { data: existing } = await github.rest.pulls.list({
+              owner,
+              repo,
+              head: `${owner}:${head}`,
+              base,
+              state: 'open',
+            });
+            let pr;
+            if (existing.length > 0) {
+              pr = existing[0];
+              core.info(`Found existing promotion PR #${pr.number}`);
+            } else {
+              const body = [
+                'Automated promotion from `codex` to `stage`.',
+                '',
+                'This pull request was opened by the codex-sync-stage workflow after passing all reusable tests.',
+              ].join('\n');
+              pr = (
+                await github.rest.pulls.create({
+                  owner,
+                  repo,
+                  head,
+                  base,
+                  title: 'Promote codex to stage',
+                  body,
+                })
+              ).data;
+              core.info(`Created promotion PR #${pr.number}`);
+            }
+            core.setOutput('number', String(pr.number));
+            core.setOutput('url', pr.html_url);
+
+      - name: Apply auto-merge label
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = Number('${{ steps.pr.outputs.number }}');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const label = process.env.AUTO_MERGE_LABEL || 'auto-merge';
+            try {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: prNumber,
+                labels: [label],
+              });
+              core.info(`Applied label "${label}" to #${prNumber}.`);
+            } catch (error) {
+              if (error.status === 404) {
+                core.warning(`Label "${label}" does not exist yet.`);
+              } else if (error.status === 422) {
+                core.info(`Label "${label}" already present on #${prNumber}.`);
+              } else {
+                throw error;
+              }
+            }
+
+      - name: Enable auto-merge or notify maintainers
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = Number('${{ steps.pr.outputs.number }}');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const mention = process.env.STAGE_MAINTAINERS || '@maintainers';
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: prNumber,
+            });
+            try {
+              await github.graphql(
+                `mutation($id:ID!){
+                  enablePullRequestAutoMerge(input:{pullRequestId:$id, mergeMethod:SQUASH}) {
+                    clientMutationId
+                  }
+                }`,
+                { id: pr.node_id }
+              );
+              core.notice(`Auto-merge enabled for promotion PR #${prNumber}.`);
+            } catch (error) {
+              core.warning(`Auto-merge enable failed: ${error.message}`);
+
+              const message = [
+                `${mention} – auto-merge could not be enabled for this codex → stage promotion.`,
+                '',
+                `> ${error.message}`,
+                '',
+                'Please review branch protections or merge manually when ready.',
+              ].join('\n');
+
+              const { data: comments } = await github.rest.issues.listComments({
+                owner,
+                repo,
+                issue_number: prNumber,
+              });
+              const duplicate = comments.find((comment) => comment.body === message);
+              if (!duplicate) {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: prNumber,
+                  body: message,
+                });
+              } else {
+                core.info('Notification comment already exists.');
+              }
+            }
+
+      - name: Share promotion link
+        run: |
+          echo "Codex → stage promotion PR: ${{ steps.pr.outputs.url }}" >> "$GITHUB_STEP_SUMMARY"

--- a/codex/README.md
+++ b/codex/README.md
@@ -1,0 +1,41 @@
+# Codex branch operations
+
+This document briefs both Codex agents and human maintainers on how the `codex` branch is promoted through the environment pipeline.
+
+## Automation workflow
+
+- Pushing commits to `codex` triggers `.github/workflows/codex-sync-stage.yml`.
+- The workflow executes the shared `.github/workflows/reusable-tests.yml` suite. Results are written to the workflow summary and exposed as outputs for downstream automations.
+- When the validation status is `passed`, the workflow opens (or refreshes) a pull request from `codex` to `stage`, labels it for auto-merge, and attempts to enable GitHub's auto-merge. If protections block auto-merge, the workflow posts a notification tagging the configured maintainers team so they can intervene manually.
+- Stage PR reviews continue to run via `.github/workflows/codex-pr-review.yml`, but linting is skipped for the auto-promotion PRs because the push workflow already validated the branch.
+
+## Codex CLI usage
+
+Codex review automation uses `scripts/automation/codex_pr_review.py`, which wraps the Codex CLI to evaluate diffs when pull requests target `codex` or `stage`. Ensure that the CLI binary is available on the runner (the action installs it automatically) and that the following inputs are configured:
+
+- `secrets.CODEX_API_KEY`
+- `vars.CODEX_BASE_URL`
+- `vars.CODEX_REVIEW_MODEL`
+
+With those values in place the workflow invokes `codex_pr_review.py` with the correct base/head SHAs and posts the generated summary back to the pull request.
+
+## Required repository configuration
+
+| Setting | Purpose |
+| --- | --- |
+| `secrets.CODEX_API_KEY` | Authenticates the Codex CLI used in review and promotion workflows. |
+| `vars.CODEX_BASE_URL` | Base URL for the Codex API. |
+| `vars.CODEX_REVIEW_MODEL` | Model identifier for the review CLI. |
+| `vars.CODEX_STAGE_MAINTAINERS` | GitHub handle or team mention (for example `@org/stage-maintainers`) that should be pinged when auto-merge cannot be enabled. |
+| `vars.CODEX_AUTO_MERGE_LABEL` | Optional label applied to the promotion PR to integrate with auto-merge policies. Defaults to `auto-merge` if unset. |
+
+Create the `auto-merge` label (or whichever custom label you configure) in the repository so the workflow can apply it without errors.
+
+## Promotion cadence
+
+- Every push to `codex` automatically attempts promotion to `stage` after passing the reusable tests.
+- Maintainers should treat the promotion pull request as the canonical view of pending changes bound for `stage`. Review the Codex summary, ensure any blocking stage checks are cleared, and merge when ready.
+- If auto-merge fails because of branch protections, respond to the workflow's notification, resolve the blocking status checks, and manually complete the merge.
+- In emergencies you can manually close the promotion PR to pause the cadence. The next successful push to `codex` will reopen it.
+
+For questions or issues with the automation, reach out to the team listed in `vars.CODEX_STAGE_MAINTAINERS`.


### PR DESCRIPTION
## Summary
- add a codex push workflow that runs the reusable tests, records their outcome, and opens an auto-mergable codex→stage PR
- update the Codex PR review workflow to cover stage promotions without re-running redundant lint checks
- document the codex branch process, required secrets, and promotion cadence

## Testing
- not run (automation only)


------
https://chatgpt.com/codex/tasks/task_e_68f3e6d74dd8832395e260213402ac59