### PR TITLE
Add Spec Kit bootstrap CLI integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: help setup-local setup-container setup-cloud compose-up compose-down \
-    backend-test frontend-test scraper-run backend-lint station-migrate station-seed
+    backend-test frontend-test scraper-run backend-lint station-migrate station-seed \
+    spec-constitution spec-plan spec-tasks spec-implement spec-specify
 
 help: ## Show help
 	@echo 'Usage: make <target>'
@@ -37,4 +38,19 @@ station-migrate: ## Run Alembic migrations for all station schemas
 	python -m scripts.bootstrap_cli station migrate
 
 station-seed: ## Seed baseline telemetry for each station
-	python -m scripts.bootstrap_cli station seed
+        python -m scripts.bootstrap_cli station seed
+
+spec-constitution: ## Run Spec Kit constitution workflow
+        python -m scripts.bootstrap_cli spec constitution
+
+spec-plan: ## Generate a Spec Kit implementation plan
+        python -m scripts.bootstrap_cli spec plan
+
+spec-tasks: ## Expand tasks using Spec Kit
+        python -m scripts.bootstrap_cli spec tasks
+
+spec-implement: ## Follow Spec Kit implementation guidance
+        python -m scripts.bootstrap_cli spec implement
+
+spec-specify: ## Run arbitrary Spec Kit commands via specify
+        python -m scripts.bootstrap_cli spec specify

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -18,6 +18,10 @@ Flags:
   --config-json    Inline JSON configuration string
   --apply          Execute infrastructure changes automatically when supported
   --configure      Run configuration management automatically when supported
+
+Spec Kit planning helpers (requires CODEX_API_KEY and optional CODEX_BASE_URL):
+  python -m scripts.bootstrap_cli spec plan
+  python -m scripts.bootstrap_cli spec tasks
 USAGE
 }
 
@@ -144,5 +148,7 @@ if [[ ! -x "$MODE_SCRIPT" ]]; then
   echo "Unsupported mode: $MODE" >&2
   exit 1
 fi
+
+echo "Spec Kit ready: export SPECIFY_FEATURE if needed and run 'python -m scripts.bootstrap_cli spec plan' to draft work."
 
 "$MODE_SCRIPT"

--- a/scripts/tests/test_bootstrap_cli_spec.py
+++ b/scripts/tests/test_bootstrap_cli_spec.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts import bootstrap_cli
+
+
+def test_resolve_specify_command_uses_uvx_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(bootstrap_cli.SPECIFY_EXECUTABLE_ENV, raising=False)
+    command = bootstrap_cli._resolve_specify_command("plan", ["--", "--dry-run", "--verbose"])
+    assert command[:5] == [
+        "uvx",
+        "--from",
+        bootstrap_cli.SPEC_KIT_PACKAGE,
+        "specify",
+        "plan",
+    ]
+    assert command[5:] == ["--dry-run", "--verbose"]
+
+
+def test_run_spec_command_sets_default_feature_and_cwd(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_run_command(command: list[str], *, cwd: Path | None = None, env: dict[str, str] | None = None) -> None:
+        captured["command"] = command
+        captured["cwd"] = cwd
+        captured["env"] = env
+
+    monkeypatch.setattr(bootstrap_cli, "run_command", fake_run_command)
+    monkeypatch.delenv("SPECIFY_FEATURE", raising=False)
+    monkeypatch.delenv(bootstrap_cli.SPECIFY_EXECUTABLE_ENV, raising=False)
+
+    bootstrap_cli.run_spec_command("plan", [])
+
+    assert captured["command"][:5] == [
+        "uvx",
+        "--from",
+        bootstrap_cli.SPEC_KIT_PACKAGE,
+        "specify",
+        "plan",
+    ]
+    assert captured["cwd"] == bootstrap_cli.REPO_ROOT
+    assert captured["env"] == {"SPECIFY_FEATURE": bootstrap_cli.SPECIFY_DEFAULT_FEATURE}
+
+
+def test_run_spec_command_respects_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_run_command(command: list[str], *, cwd: Path | None = None, env: dict[str, str] | None = None) -> None:
+        captured["command"] = command
+        captured["cwd"] = cwd
+        captured["env"] = env
+
+    monkeypatch.setattr(bootstrap_cli, "run_command", fake_run_command)
+    monkeypatch.setenv("SPECIFY_FEATURE", "vtoc")
+    monkeypatch.setenv(bootstrap_cli.SPECIFY_EXECUTABLE_ENV, "/tmp/specify")
+
+    bootstrap_cli.run_spec_command("tasks", ["--dry-run"])
+
+    assert captured["command"] == ["/tmp/specify", "tasks", "--dry-run"]
+    assert captured["cwd"] == bootstrap_cli.REPO_ROOT
+    assert captured["env"] == {"SPECIFY_FEATURE": "vtoc"}
+
+
+def test_spec_parser_passes_through_arguments(monkeypatch: pytest.MonkeyPatch) -> None:
+    parser = bootstrap_cli.build_parser()
+    args = parser.parse_args(["spec", "implement", "--", "--fast", "--owner", "@vtoc"])
+
+    called: dict[str, Any] = {}
+
+    def fake_run_spec_command(subcommand: str, extra_args: list[str]) -> None:
+        called["subcommand"] = subcommand
+        called["extra_args"] = extra_args
+
+    monkeypatch.setattr(bootstrap_cli, "run_spec_command", fake_run_spec_command)
+
+    args.func(args)
+
+    assert called == {
+        "subcommand": "implement",
+        "extra_args": ["--", "--fast", "--owner", "@vtoc"],
+    }


### PR DESCRIPTION
## Summary
- add a Spec Kit command group to `scripts/bootstrap_cli.py` that shells out through `uvx` with environment documentation
- wire new Spec Kit targets into the Makefile and surface guidance in the setup script
- add tests covering Spec Kit command wiring and passthrough behaviour

## Testing
- pytest scripts/tests/test_bootstrap_cli_spec.py

------
https://chatgpt.com/codex/tasks/task_e_68f4f0cd45f08323ab8724c910a6b255