### PR TITLE
Normalize Supabase configuration and tests

### DIFF
--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -63,9 +63,14 @@ def _initialise_supabase_client() -> None:
     if not settings.supabase_enabled:
         return
 
+    url = settings.supabase_url or ""
+    key = settings.supabase_key
+    if not url or not key:
+        return
+
     SUPABASE_CLIENT = create_client(
-        settings.supabase_url,
-        settings.supabase_service_role_key,
+        url,
+        key,
         options=ClientOptions(
             postgrest_client_timeout=settings.supabase_pool_timeout_seconds,
         ),

--- a/backend/app/services/supabase.py
+++ b/backend/app/services/supabase.py
@@ -37,15 +37,16 @@ class SupabaseRepository:
             raise SupabaseApiError(
                 status.HTTP_503_SERVICE_UNAVAILABLE, "Supabase is not configured"
             )
-        base_url = settings.supabase_url.rstrip("/")
+        base_url = (settings.supabase_url or "").rstrip("/")
+        key = settings.supabase_key
         self._client = client or httpx.Client(
             base_url=f"{base_url}/rest/v1",
             timeout=settings.supabase_timeout_seconds,
         )
         self._schema = settings.supabase_schema
         self._headers: Dict[str, str] = {
-            "apikey": settings.supabase_key,
-            "Authorization": f"Bearer {settings.supabase_key}",
+            "apikey": key,
+            "Authorization": f"Bearer {key}",
             "Content-Type": "application/json",
             "Accept": "application/json",
         }

--- a/backend/tests/test_supabase_repository.py
+++ b/backend/tests/test_supabase_repository.py
@@ -1,0 +1,47 @@
+import pytest
+from fastapi import status
+
+from backend.app.config import Settings
+from backend.app.services.supabase import SupabaseApiError, SupabaseRepository
+
+
+class DummyClient:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def request(self, *args, **kwargs):
+        raise AssertionError("No HTTP calls expected in tests")
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _settings(**kwargs) -> Settings:
+    defaults = {
+        "supabase_url": "https://example.supabase.co",
+        "supabase_service_role_key": "service-role",
+    }
+    defaults.update(kwargs)
+    return Settings(**defaults)
+
+
+def test_supabase_repository_initialises_with_configured_settings() -> None:
+    repo = SupabaseRepository(settings=_settings(), client=DummyClient())
+    assert repo._headers["apikey"] == "service-role"
+    assert repo._headers["Authorization"] == "Bearer service-role"
+
+
+def test_supabase_repository_uses_anon_key_when_service_role_missing() -> None:
+    settings = _settings(supabase_service_role_key=None, supabase_anon_key="anon-key")
+    repo = SupabaseRepository(settings=settings, client=DummyClient())
+    assert repo._headers["apikey"] == "anon-key"
+    assert repo._headers["Authorization"] == "Bearer anon-key"
+
+
+def test_supabase_repository_raises_when_supabase_disabled() -> None:
+    settings = Settings()
+    with pytest.raises(SupabaseApiError) as excinfo:
+        SupabaseRepository(settings=settings, client=DummyClient())
+
+    assert excinfo.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert "not configured" in excinfo.value.detail


### PR DESCRIPTION
## Summary
- consolidate Supabase configuration by adding key accessors, anon key support, and removing duplicate url fields
- update Supabase client initialisation to rely on the new helpers
- add repository unit tests covering configured and disabled Supabase scenarios

## Testing
- PYTHONPATH=. pytest backend/tests/test_supabase_repository.py

------
https://chatgpt.com/codex/tasks/task_e_68f505d8d5ac8323aac10d7ccce7521a