### PR TITLE
Refactor station slug resolution into shared helper

### DIFF
--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -13,6 +13,7 @@ from supabase import Client, create_client
 from supabase.lib.client_options import ClientOptions
 
 from .config import get_settings
+from .utils.stations import resolve_station_slug as _resolve_station_slug_from_headers
 
 Base = declarative_base()
 
@@ -125,21 +126,9 @@ def session_scope(station_slug: Optional[str] = None) -> Generator[Session, None
 
 
 def _resolve_station_slug(request: Request) -> Optional[str]:
-    candidate_headers = (
-        "x-station-id",
-        "x-station-slug",
-        "x-chatkit-station",
-        "x-toc-station",
+    return _resolve_station_slug_from_headers(
+        request.headers, SESSION_FACTORY_BY_STATION.keys()
     )
-
-    for header in candidate_headers:
-        value = request.headers.get(header)
-        if not value:
-            continue
-        slug = value.replace("_", "-").lower()
-        if slug in SESSION_FACTORY_BY_STATION:
-            return slug
-    return None
 
 
 def get_db(station_slug: Optional[str] = None) -> Generator[Session, None, None]:

--- a/backend/app/services/supabase.py
+++ b/backend/app/services/supabase.py
@@ -9,13 +9,7 @@ from fastapi import Depends, HTTPException, Request, status
 
 from .. import schemas
 from ..config import Settings, get_settings
-
-STATION_HEADER_CANDIDATES = (
-    "x-station-id",
-    "x-station-slug",
-    "x-chatkit-station",
-    "x-toc-station",
-)
+from ..utils.stations import resolve_station_slug as _resolve_station_slug_from_headers
 
 TELEMETRY_SCHEMA = "telemetry"
 
@@ -840,14 +834,7 @@ class SupabaseRepository:
 
 def resolve_station_slug(request: Request) -> Optional[str]:
     """Infer the station slug from common headers."""
-    for header in STATION_HEADER_CANDIDATES:
-        value = request.headers.get(header)
-        if not value:
-            continue
-        slug = value.replace("_", "-").lower()
-        if slug:
-            return slug
-    return None
+    return _resolve_station_slug_from_headers(request.headers, None)
 
 
 def get_station_context(request: Request) -> Optional[str]:

--- a/backend/app/utils/__init__.py
+++ b/backend/app/utils/__init__.py
@@ -1,0 +1,3 @@
+"""Utility helpers for the backend application."""
+
+__all__ = []

--- a/backend/app/utils/stations.py
+++ b/backend/app/utils/stations.py
@@ -1,0 +1,52 @@
+"""Helpers for resolving station context from HTTP requests."""
+from __future__ import annotations
+
+from typing import Iterable, Mapping, Optional
+
+STATION_HEADER_CANDIDATES = (
+    "x-station-id",
+    "x-station-slug",
+    "x-chatkit-station",
+    "x-toc-station",
+)
+
+
+def _normalise_slug(value: str) -> str:
+    """Normalise a station slug value from headers."""
+    return value.replace("_", "-").lower()
+
+
+def resolve_station_slug(
+    headers: Mapping[str, str], known_slugs: Optional[Iterable[str]]
+) -> Optional[str]:
+    """Resolve the station slug from the provided headers.
+
+    Args:
+        headers: A mapping of header names to values.
+        known_slugs: An optional iterable of slugs that are considered valid.
+
+    Returns:
+        The normalised station slug if one can be determined, otherwise ``None``.
+    """
+
+    allowed_slugs = None
+    if known_slugs is not None:
+        allowed_slugs = {slug.lower() for slug in known_slugs}
+
+    for header in STATION_HEADER_CANDIDATES:
+        value = headers.get(header)
+        if not value:
+            continue
+        slug = _normalise_slug(value)
+        if not slug:
+            continue
+        if allowed_slugs is not None and slug not in allowed_slugs:
+            continue
+        return slug
+    return None
+
+
+__all__ = [
+    "STATION_HEADER_CANDIDATES",
+    "resolve_station_slug",
+]

--- a/backend/tests/test_station_utils.py
+++ b/backend/tests/test_station_utils.py
@@ -1,0 +1,79 @@
+"""Tests for station header resolution helpers."""
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from typing import Dict
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.append(str(PROJECT_ROOT))
+
+import pytest
+
+from backend.app.utils import stations
+
+
+class DummyRequest:
+    def __init__(self, headers: Dict[str, str]) -> None:
+        self.headers = headers
+
+
+def test_resolve_station_slug_normalises_and_filters_known_slugs() -> None:
+    headers = {"x-station-id": "Station_ONE"}
+    result = stations.resolve_station_slug(headers, {"station-one", "station-two"})
+    assert result == "station-one"
+
+
+def test_resolve_station_slug_returns_none_for_unknown_when_knowns_provided() -> None:
+    headers = {"x-station-id": "unknown"}
+    result = stations.resolve_station_slug(headers, {"station-one"})
+    assert result is None
+
+
+def test_resolve_station_slug_allows_unknown_when_no_knowns() -> None:
+    headers = {"x-station-slug": "Station_THREE"}
+    result = stations.resolve_station_slug(headers, None)
+    assert result == "station-three"
+
+
+def test_supabase_resolve_station_slug_delegates(monkeypatch: pytest.MonkeyPatch) -> None:
+    supabase = importlib.import_module("backend.app.services.supabase")
+    request = DummyRequest({"x-station-id": "Station"})
+    sentinel = object()
+
+    def fake(headers, known_slugs):  # type: ignore[no-untyped-def]
+        assert headers is request.headers
+        assert known_slugs is None
+        return sentinel
+
+    monkeypatch.setattr(
+        supabase,
+        "_resolve_station_slug_from_headers",
+        fake,
+    )
+
+    assert supabase.resolve_station_slug(request) is sentinel
+
+
+def test_db_resolve_station_slug_delegates(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", "sqlite://")
+    db = importlib.import_module("backend.app.db")
+    db = importlib.reload(db)
+    request = DummyRequest({"x-station-slug": "Station"})
+    sentinel = object()
+
+    def fake(headers, known_slugs):  # type: ignore[no-untyped-def]
+        assert headers is request.headers
+        assert list(known_slugs) == list(db.SESSION_FACTORY_BY_STATION.keys())
+        return sentinel
+
+    monkeypatch.setattr(
+        db,
+        "_resolve_station_slug_from_headers",
+        fake,
+    )
+
+    assert db._resolve_station_slug(request) is sentinel


### PR DESCRIPTION
## Summary
- add a shared station header helper with normalization logic
- update database and supabase modules to consume the shared helper
- add regression tests verifying helper behaviour and call site delegation

## Testing
- pytest backend/tests/test_station_utils.py


------
https://chatgpt.com/codex/tasks/task_e_68f505dcac8c832388e50ee2209827dd