### PR TITLE
Add station timeline endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ The FastAPI backend (`backend/app`) provides:
 * `/api/v1/telemetry/*` — CRUD for telemetry sources and events
 * `/api/v1/chatkit/webhook` — Receives ChatKit events and launches AgentKit runs scoped to the station role
 * `/api/v1/stations` — Registers and reports station metadata
+* `/api/v1/stations/{station_slug}/timeline` — Returns a merged, paginated timeline of telemetry events and AgentKit audits
 
 Database connectivity is supplied through `DATABASE_URL`. SQLAlchemy models and Alembic migrations live under `backend/app` and
 `alembic/`. Run migrations with:

--- a/backend/app/routers/__init__.py
+++ b/backend/app/routers/__init__.py
@@ -1,5 +1,5 @@
 """API routers."""
 from . import hardware, telemetry
-from .stations import dashboard, tasks, agentkit
+from .stations import agentkit, dashboard, tasks, timeline
 
-__all__ = ["hardware", "telemetry", "dashboard", "tasks", "agentkit"]
+__all__ = ["hardware", "telemetry", "dashboard", "tasks", "agentkit", "timeline"]

--- a/backend/app/routers/stations/__init__.py
+++ b/backend/app/routers/stations/__init__.py
@@ -1,11 +1,12 @@
 """Station-scoped routers."""
 from fastapi import APIRouter
 
-from . import agentkit, dashboard, tasks
+from . import agentkit, dashboard, tasks, timeline
 
 router = APIRouter()
 router.include_router(dashboard.router)
 router.include_router(tasks.router)
 router.include_router(agentkit.router)
+router.include_router(timeline.router)
 
-__all__ = ["router", "dashboard", "tasks", "agentkit"]
+__all__ = ["router", "dashboard", "tasks", "agentkit", "timeline"]

--- a/backend/app/routers/stations/timeline.py
+++ b/backend/app/routers/stations/timeline.py
@@ -1,0 +1,37 @@
+"""Station timeline endpoints."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from ... import schemas
+from ...services.supabase import (
+    SupabaseApiError,
+    SupabaseRepository,
+    get_supabase_repository,
+)
+
+router = APIRouter(prefix="/api/v1/stations", tags=["station-timeline"])
+
+
+@router.get(
+    "/{station_slug}/timeline",
+    response_model=schemas.StationTimelinePage,
+    status_code=status.HTTP_200_OK,
+)
+def station_timeline(
+    station_slug: str,
+    limit: int = Query(50, ge=0, le=200),
+    offset: int = Query(0, ge=0),
+    repo: SupabaseRepository = Depends(get_supabase_repository),
+) -> schemas.StationTimelinePage:
+    """Return a merged timeline of telemetry and agent activity for a station."""
+
+    try:
+        return repo.list_station_timeline_entries(
+            station_slug, limit=limit, offset=offset
+        )
+    except SupabaseApiError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+
+
+__all__ = ["router", "station_timeline"]

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, List, Optional
+from typing import Annotated, Any, List, Literal, Optional, Union
 
 from pydantic import BaseModel, Field
 
@@ -334,3 +334,47 @@ class AgentActionAuditRead(
     ORMModelMixin, AgentActionAuditBase, IdentifierMixin, TimestampsMixin
 ):
     completed_at: Optional[datetime] = None
+
+
+class StationTimelineBase(BaseModel):
+    """Base fields for station timeline entries."""
+
+    occurred_at: datetime
+
+
+class StationTimelineTelemetryEntry(StationTimelineBase):
+    """Timeline entry representing a telemetry event."""
+
+    entry_type: Literal["telemetry_event"] = "telemetry_event"
+    event_id: int
+    status: Optional[str] = None
+    source_slug: Optional[str] = None
+    source_name: Optional[str] = None
+    payload: Optional[dict[str, Any]] = None
+
+
+class StationTimelineAgentActionEntry(StationTimelineBase):
+    """Timeline entry representing an AgentKit audit row."""
+
+    entry_type: Literal["agent_action_audit"] = "agent_action_audit"
+    audit_id: int
+    action_id: str
+    tool_name: str
+    status: str
+    response_payload: Optional[dict[str, Any]] = None
+    error_message: Optional[str] = None
+
+
+StationTimelineEntry = Annotated[
+    Union[StationTimelineTelemetryEntry, StationTimelineAgentActionEntry],
+    Field(discriminator="entry_type"),
+]
+
+
+class StationTimelinePage(BaseModel):
+    """Paginated collection of station timeline entries."""
+
+    items: List[StationTimelineEntry]
+    limit: int
+    offset: int
+    total: Optional[int] = None

--- a/backend/app/services/supabase.py
+++ b/backend/app/services/supabase.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Dict, Generator, List, Optional
+from typing import Any, Dict, Generator, Iterable, List, Optional
 
 import httpx
 from fastapi import Depends, HTTPException, Request, status
@@ -225,6 +225,167 @@ class SupabaseRepository:
             )
             tasks.append(task)
         return schemas.StationTaskQueue(station=station, tasks=tasks)
+
+    # ------------------------------------------------------------------
+    # Station timeline
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _parse_timestamp(value: Any) -> Optional[datetime]:
+        if value is None:
+            return None
+        if isinstance(value, datetime):
+            return value
+        if isinstance(value, str):
+            try:
+                return datetime.fromisoformat(value.replace("Z", "+00:00"))
+            except ValueError:
+                return None
+        return None
+
+    def _fetch_station_timeline_telemetry_records(
+        self, station_id: int, limit: int
+    ) -> List[Dict[str, Any]]:
+        if limit <= 0:
+            return []
+        response = self._request(
+            "GET",
+            "telemetry_events",
+            params={
+                "select": "id,event_time,received_at,created_at,status,payload,"
+                "source:telemetry_sources(slug,name)",
+                "station_id": f"eq.{station_id}",
+                "order": "event_time.desc.nullslast,received_at.desc.nullslast,"
+                "created_at.desc",
+            },
+            headers={"Range": f"0-{max(limit - 1, 0)}"},
+        )
+        return self._json(response) or []
+
+    def _fetch_station_timeline_agent_audit_records(
+        self, station_id: int, limit: int
+    ) -> List[Dict[str, Any]]:
+        if limit <= 0:
+            return []
+        response = self._request(
+            "GET",
+            "agent_action_audits",
+            params={
+                "select": "id,action_id,tool_name,status,response_payload,error_message,"
+                "completed_at,updated_at,created_at",
+                "station_id": f"eq.{station_id}",
+                "order": "completed_at.desc.nullslast,updated_at.desc.nullslast,"
+                "created_at.desc",
+            },
+            headers={"Range": f"0-{max(limit - 1, 0)}"},
+        )
+        return self._json(response) or []
+
+    @staticmethod
+    def _normalize_timeline_telemetry(
+        records: Iterable[Dict[str, Any]]
+    ) -> List[schemas.StationTimelineTelemetryEntry]:
+        entries: List[schemas.StationTimelineTelemetryEntry] = []
+        for record in records:
+            occurred_at = SupabaseRepository._parse_timestamp(
+                record.get("event_time")
+                or record.get("received_at")
+                or record.get("created_at")
+            )
+            if occurred_at is None:
+                continue
+            source = record.get("source") or {}
+            try:
+                event_id = int(record["id"])
+            except (KeyError, TypeError, ValueError):
+                continue
+            entry = schemas.StationTimelineTelemetryEntry(
+                occurred_at=occurred_at,
+                event_id=event_id,
+                status=record.get("status"),
+                source_slug=source.get("slug"),
+                source_name=source.get("name"),
+                payload=record.get("payload"),
+            )
+            entries.append(entry)
+        return entries
+
+    @staticmethod
+    def _normalize_timeline_agent_audits(
+        records: Iterable[Dict[str, Any]]
+    ) -> List[schemas.StationTimelineAgentActionEntry]:
+        entries: List[schemas.StationTimelineAgentActionEntry] = []
+        for record in records:
+            occurred_at = SupabaseRepository._parse_timestamp(
+                record.get("completed_at")
+                or record.get("updated_at")
+                or record.get("created_at")
+            )
+            if occurred_at is None:
+                continue
+            try:
+                audit_id = int(record["id"])
+            except (KeyError, TypeError, ValueError):
+                continue
+            action_id = record.get("action_id")
+            tool_name = record.get("tool_name")
+            status = record.get("status")
+            if not action_id or not tool_name or not status:
+                continue
+            entry = schemas.StationTimelineAgentActionEntry(
+                occurred_at=occurred_at,
+                audit_id=audit_id,
+                action_id=str(action_id),
+                tool_name=str(tool_name),
+                status=str(status),
+                response_payload=record.get("response_payload"),
+                error_message=record.get("error_message"),
+            )
+            entries.append(entry)
+        return entries
+
+    def list_station_timeline_entries(
+        self, station_slug: str, *, limit: int = 50, offset: int = 0
+    ) -> schemas.StationTimelinePage:
+        limit = max(limit, 0)
+        offset = max(offset, 0)
+        station = self.get_station(station_slug)
+        fetch_window = max(limit + offset, 1)
+
+        telemetry_records = self._fetch_station_timeline_telemetry_records(
+            station.id, fetch_window * 2
+        )
+        audit_records = self._fetch_station_timeline_agent_audit_records(
+            station.id, fetch_window * 2
+        )
+
+        telemetry_entries = self._normalize_timeline_telemetry(telemetry_records)
+        audit_entries = self._normalize_timeline_agent_audits(audit_records)
+
+        combined: List[schemas.StationTimelineEntry] = [
+            *telemetry_entries,
+            *audit_entries,
+        ]
+        combined.sort(key=lambda entry: entry.occurred_at, reverse=True)
+
+        total_events = self._count(
+            "telemetry_events", {"station_id": f"eq.{station.id}"}
+        )
+        total_audits = self._count(
+            "agent_action_audits", {"station_id": f"eq.{station.id}"}
+        )
+        total = total_events + total_audits
+
+        if limit == 0:
+            items: List[schemas.StationTimelineEntry] = []
+        else:
+            items = combined[offset : offset + limit]
+
+        return schemas.StationTimelinePage(
+            items=items,
+            limit=limit,
+            offset=offset,
+            total=total,
+        )
 
     # ------------------------------------------------------------------
     # Base stations

--- a/backend/tests/stations/test_timeline.py
+++ b/backend/tests/stations/test_timeline.py
@@ -1,0 +1,183 @@
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.app import schemas
+from backend.app.config import Settings
+from backend.app.main import app
+from backend.app.services.supabase import (
+    SupabaseRepository,
+    get_supabase_repository,
+)
+
+
+class DummyClient:
+    def request(self, *args: Any, **kwargs: Any) -> None:
+        raise AssertionError("HTTP calls should not be made in timeline tests")
+
+    def close(self) -> None:
+        pass
+
+
+class FakeTimelineRepository(SupabaseRepository):
+    def __init__(
+        self,
+        settings: Settings,
+        telemetry_records: List[Dict[str, Any]],
+        audit_records: List[Dict[str, Any]],
+    ) -> None:
+        super().__init__(settings=settings, client=DummyClient())
+        now = datetime.now(timezone.utc)
+        self._station = schemas.StationRead(
+            id=1,
+            name="Test Station",
+            slug="test-station",
+            description="Station used for timeline tests",
+            timezone="UTC",
+            telemetry_schema=None,
+            created_at=now,
+            updated_at=now,
+        )
+        self._telemetry_all = telemetry_records
+        self._audits_all = audit_records
+
+    def close(self) -> None:  # pragma: no cover - no external resources
+        pass
+
+    def get_station(self, station_slug: str) -> schemas.StationRead:  # type: ignore[override]
+        return self._station
+
+    def _fetch_station_timeline_telemetry_records(  # type: ignore[override]
+        self, station_id: int, limit: int
+    ) -> List[Dict[str, Any]]:
+        if limit <= 0:
+            return []
+        return self._telemetry_all[:limit]
+
+    def _fetch_station_timeline_agent_audit_records(  # type: ignore[override]
+        self, station_id: int, limit: int
+    ) -> List[Dict[str, Any]]:
+        if limit <= 0:
+            return []
+        return self._audits_all[:limit]
+
+    def _count(self, table: str, filters: Dict[str, Any]) -> int:  # type: ignore[override]
+        if table == "telemetry_events":
+            return len(self._telemetry_all)
+        if table == "agent_action_audits":
+            return len(self._audits_all)
+        return 0
+
+
+@pytest.fixture()
+def timeline_repo() -> FakeTimelineRepository:
+    base = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+    telemetry_records = [
+        {
+            "id": 101,
+            "event_time": (base - timedelta(minutes=5)).isoformat(),
+            "received_at": (base - timedelta(minutes=5)).isoformat(),
+            "created_at": (base - timedelta(minutes=5)).isoformat(),
+            "status": "received",
+            "payload": {"value": 101},
+            "source": {"slug": "primary-radar", "name": "Primary Radar"},
+        },
+        {
+            "id": 102,
+            "event_time": None,
+            "received_at": (base - timedelta(minutes=1)).isoformat(),
+            "created_at": (base - timedelta(minutes=1)).isoformat(),
+            "status": "received",
+            "payload": {"value": 102},
+            "source": {"slug": "primary-radar", "name": "Primary Radar"},
+        },
+        {
+            "id": 103,
+            "event_time": (base - timedelta(minutes=9)).isoformat(),
+            "received_at": (base - timedelta(minutes=9)).isoformat(),
+            "created_at": (base - timedelta(minutes=9)).isoformat(),
+            "status": "received",
+            "payload": {"value": 103},
+            "source": {"slug": "primary-radar", "name": "Primary Radar"},
+        },
+    ]
+    audit_records = [
+        {
+            "id": 201,
+            "action_id": "audit-1",
+            "tool_name": "ping",
+            "status": "succeeded",
+            "response_payload": {"ok": True},
+            "error_message": None,
+            "completed_at": (base - timedelta(minutes=3)).isoformat(),
+            "updated_at": (base - timedelta(minutes=3)).isoformat(),
+            "created_at": (base - timedelta(minutes=4)).isoformat(),
+        },
+        {
+            "id": 202,
+            "action_id": "audit-2",
+            "tool_name": "ping",
+            "status": "failed",
+            "response_payload": None,
+            "error_message": "timeout",
+            "completed_at": None,
+            "updated_at": (base - timedelta(minutes=6)).isoformat(),
+            "created_at": (base - timedelta(minutes=7)).isoformat(),
+        },
+    ]
+    settings = Settings(
+        supabase_url="https://example.supabase.co",
+        supabase_service_role_key="service-role",
+    )
+    return FakeTimelineRepository(settings, telemetry_records, audit_records)
+
+
+@pytest.fixture()
+def client(timeline_repo: FakeTimelineRepository) -> TestClient:
+    test_client = TestClient(app)
+    app.dependency_overrides[get_supabase_repository] = lambda: timeline_repo
+    try:
+        yield test_client
+    finally:
+        app.dependency_overrides.pop(get_supabase_repository, None)
+        test_client.close()
+
+
+def test_station_timeline_orders_entries_desc(client: TestClient) -> None:
+    response = client.get("/api/v1/stations/test-station/timeline")
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["total"] == 5
+    occurred_at_values = [item["occurred_at"] for item in payload["items"]]
+    assert occurred_at_values == sorted(occurred_at_values, reverse=True)
+
+    first_entry = payload["items"][0]
+    assert first_entry["entry_type"] == "telemetry_event"
+    assert first_entry["event_id"] == 102
+
+    second_entry = payload["items"][1]
+    assert second_entry["entry_type"] == "agent_action_audit"
+    assert second_entry["audit_id"] == 201
+
+
+def test_station_timeline_supports_pagination(client: TestClient) -> None:
+    response = client.get(
+        "/api/v1/stations/test-station/timeline",
+        params={"limit": 2, "offset": 1},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["limit"] == 2
+    assert payload["offset"] == 1
+    assert payload["total"] == 5
+    assert len(payload["items"]) == 2
+
+    # Entries should represent the 2nd and 3rd most recent timeline items
+    entry_types = [item["entry_type"] for item in payload["items"]]
+    assert entry_types == ["agent_action_audit", "telemetry_event"]
+    assert payload["items"][0]["audit_id"] == 201
+    assert payload["items"][1]["event_id"] == 101

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,6 +41,8 @@ ChatKit organization. This document describes the high-level architecture and th
   mission console. Reads `STATION_CALLSIGN` and `POSTGRES_STATION_ROLE` from `.env.station`.
 - **Backend** — FastAPI service exposing REST endpoints, ChatKit webhook listeners, and telemetry ingestion APIs. It maps channel
   events to AgentKit playbooks based on the station role and persists results to Supabase-hosted Postgres schemas.
+  - `/api/v1/stations/{station_slug}/timeline` merges recent telemetry events with AgentKit audits so operators can review a
+    unified activity feed per station.
 - **Supabase Postgres** — Managed Postgres instance with per-role schemas (`ops`, `intel`, `logistics`). Supabase enforces
   row-level security policies aligned with station metadata and exposes realtime feeds for the frontend.
 - **ChatKit Organization** — Shared chat fabric for operators and automated agents. Each station owns a default channel named


### PR DESCRIPTION
## Summary
- add timeline schema models that normalise telemetry and AgentKit audit entries for stations
- implement Supabase repository helpers and a router endpoint to serve `/api/v1/stations/{station_slug}/timeline`
- cover the merged timeline with FastAPI tests and document the new endpoint in the README and architecture overview

## Testing
- pytest -q *(fails: missing optional service packages such as scripts.configure_readsb and gps_ingest)*

------
https://chatgpt.com/codex/tasks/task_e_68f548053e888323b9a20fe8ad73fe58