### PR TITLE
Add ChatKit context fields to agent action audits

### DIFF
--- a/alembic/versions/20240418_0001_agent_action_context.py
+++ b/alembic/versions/20240418_0001_agent_action_context.py
@@ -1,0 +1,27 @@
+"""Add ChatKit context to agent action audits."""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20240418_0001"
+down_revision = "20240210_0002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agent_action_audits",
+        sa.Column("channel_slug", sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        "agent_action_audits",
+        sa.Column("initiator_id", sa.String(length=255), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("agent_action_audits", "initiator_id")
+    op.drop_column("agent_action_audits", "channel_slug")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -293,6 +293,8 @@ class AgentActionExecuteRequest(BaseModel):
     tool_name: str
     action_input: dict[str, Any]
     metadata: dict[str, Any] | None = None
+    channel_slug: Optional[str] = None
+    initiator_id: Optional[str] = None
 
 
 class AgentActionExecuteResponse(BaseModel):
@@ -307,6 +309,8 @@ class AgentActionWebhookEvent(BaseModel):
     status: str
     result: Optional[dict[str, Any]] = None
     error: Optional[str] = None
+    channel_slug: Optional[str] = None
+    initiator_id: Optional[str] = None
 
 
 class AgentActionAuditBase(BaseModel):
@@ -316,6 +320,8 @@ class AgentActionAuditBase(BaseModel):
     request_payload: Optional[dict[str, Any]] = None
     response_payload: Optional[dict[str, Any]] = None
     error_message: Optional[str] = None
+    channel_slug: Optional[str] = None
+    initiator_id: Optional[str] = None
 
 
 class AgentActionAuditCreate(AgentActionAuditBase):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -73,6 +73,16 @@ Playbook identifiers are defined under `agents/config/agentkit.yml`. The backend
 5. Results are stored in Supabase Postgres and posted back to ChatKit. Frontend receives updates through the standard REST
    polling cycle.
 
+#### Agent action audit context
+
+- AgentKit invocations that flow through `/api/v1/agent-actions/execute` may carry optional ChatKit hints in the payload.
+  Supply `channel_slug` and `initiator_id` either at the top level of the request body or inside the `metadata` object to
+  persist the originating chat context alongside the audit record.
+- ChatKit requests should include `X-ChatKit-Channel` (or `X-ChatKit-Thread`) and `X-ChatKit-User`/`X-ChatKit-Initiator`
+  headers. The backend uses them as fallbacks when the JSON payload omits explicit context.
+- Webhook callbacks can mirror the same `channel_slug` and `initiator_id` fields in their JSON body. The backend keeps the
+  audit log up to date when the action completes, ensuring Supabase rows contain both execution status and chat metadata.
+
 ### Telemetry ingestion
 
 1. Telemetry connector (standalone agent or AgentKit task) fetches external data.


### PR DESCRIPTION
## Summary
- add optional `channel_slug` and `initiator_id` fields to agent action audit schemas and persistence
- propagate ChatKit context from execute requests and webhook payloads into Supabase audit records
- cover the new context metadata with backend tests, migration, and documentation updates

## Testing
- alembic upgrade head *(fails: Attribute name 'metadata' is reserved for the MetaData instance when using a declarative base class.)*
- PYTHONPATH=. pytest -q backend/tests/test_agent_actions.py

------
https://chatgpt.com/codex/tasks/task_e_68f54808fdb483239586119706757ac8