### PR TITLE
Add ChatKit console integration to app shell

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -48,6 +48,11 @@ The build output lands in `dist/` and is consumed by the nginx-based container i
 - `VITE_API_URL` — override backend base URL (defaults to `http://localhost:8080`).
 - `VITE_STATION_CALLSIGN` — set automatically from `.env.station`.
 - `VITE_STATION_ROLE` — used to scope mission widgets and ChatKit thread filters.
+- `VITE_CHATKIT_API_KEY` — enables the embedded ChatKit console when paired with the variables below.
+- `VITE_AGENTKIT_ORG_ID` — organization identifier passed to ChatKit for routing agent actions.
+- `VITE_CHATKIT_WIDGET_URL` — URL of the ChatKit web component bundle to hydrate the console UI.
+- `VITE_AGENTKIT_DEFAULT_STATION_CONTEXT` — optional override for the default station context shared with ChatKit (defaults to `toc-s1`).
+- `VITE_CHATKIT_TELEMETRY_CHANNEL` — optional telemetry channel name used to scope real-time event streams.
 
 Refer to [`docs/QUICKSTART.md`](../docs/QUICKSTART.md) for the station bootstrap workflow and to [`CONTRIBUTING.md`](../CONTRIBUTING.md)
 for testing expectations.

--- a/frontend/src/components/chatkit/ChatKitWidget.test.tsx
+++ b/frontend/src/components/chatkit/ChatKitWidget.test.tsx
@@ -22,6 +22,7 @@ describe('ChatKitWidget', () => {
   it('renders the chatkit custom element when configured', async () => {
     vi.stubEnv('VITE_CHATKIT_API_KEY', 'test');
     vi.stubEnv('VITE_AGENTKIT_ORG_ID', 'org');
+    vi.stubEnv('VITE_CHATKIT_WIDGET_URL', 'https://example.com/widget.js');
 
     const { container } = render(<ChatKitWidget telemetry={telemetry} />);
     await waitFor(() => {
@@ -32,6 +33,7 @@ describe('ChatKitWidget', () => {
   it('passes Supabase session data through data attributes', async () => {
     vi.stubEnv('VITE_CHATKIT_API_KEY', 'test');
     vi.stubEnv('VITE_AGENTKIT_ORG_ID', 'org');
+    vi.stubEnv('VITE_CHATKIT_WIDGET_URL', 'https://example.com/widget.js');
 
     const richTelemetry = {
       ...telemetry,
@@ -52,6 +54,71 @@ describe('ChatKitWidget', () => {
       expect(widget?.getAttribute('data-supabase-refresh-token')).toBe('refresh-123');
       expect(widget?.getAttribute('data-supabase-user-id')).toBe('user-123');
       expect(widget?.getAttribute('data-telemetry-channel')).toBe('custom-channel');
+    });
+  });
+
+  it('updates the custom element context when telemetry changes', async () => {
+    vi.stubEnv('VITE_CHATKIT_API_KEY', 'test');
+    vi.stubEnv('VITE_AGENTKIT_ORG_ID', 'org');
+    vi.stubEnv('VITE_CHATKIT_WIDGET_URL', 'https://example.com/widget.js');
+
+    const { container, rerender } = render(<ChatKitWidget telemetry={telemetry} />);
+
+    await waitFor(() => {
+      expect(container.querySelector('chatkit-assistant')).not.toBeNull();
+    });
+
+    const widget = container.querySelector('chatkit-assistant') as HTMLElement & {
+      context?: typeof telemetry;
+    };
+
+    expect(widget?.context).toEqual(expect.objectContaining(telemetry));
+
+    const updatedTelemetry = {
+      ...telemetry,
+      events: [
+        {
+          id: 1,
+          source_id: 1,
+          status: 'received',
+          received_at: '2024-03-12T10:00:00Z',
+          source: {
+            id: 1,
+            name: 'sensor-1',
+            slug: 'sensor-1',
+            source_type: 'radar',
+          },
+        },
+      ],
+      lastEventTimestamp: '2024-03-12T10:00:00Z',
+    };
+
+    rerender(<ChatKitWidget telemetry={updatedTelemetry} />);
+
+    await waitFor(() => {
+      expect(widget?.context).toEqual(expect.objectContaining(updatedTelemetry));
+    });
+  });
+
+  it('toggles visibility based on the open prop', async () => {
+    vi.stubEnv('VITE_CHATKIT_API_KEY', 'test');
+    vi.stubEnv('VITE_AGENTKIT_ORG_ID', 'org');
+    vi.stubEnv('VITE_CHATKIT_WIDGET_URL', 'https://example.com/widget.js');
+
+    const { container, rerender } = render(<ChatKitWidget telemetry={telemetry} open={false} />);
+
+    await waitFor(() => {
+      expect(container.querySelector('chatkit-assistant')).not.toBeNull();
+    });
+
+    let widget = container.querySelector('chatkit-assistant') as HTMLElement;
+    expect(widget.style.display).toBe('none');
+
+    rerender(<ChatKitWidget telemetry={telemetry} open />);
+
+    await waitFor(() => {
+      widget = container.querySelector('chatkit-assistant') as HTMLElement;
+      expect(widget.style.display).toBe('block');
     });
   });
 });

--- a/frontend/src/pages/App.tsx
+++ b/frontend/src/pages/App.tsx
@@ -1,6 +1,10 @@
+import { useMemo, useState } from 'react';
 import { NavLink } from 'react-router-dom';
 
+import ChatKitWidget from '../components/chatkit/ChatKitWidget';
+import SetupWizard from '../features/setup/SetupWizard';
 import AppRouter from '../router';
+import { useSupabaseSession, useTelemetryEvents } from '../services/api';
 
 const StationNav = () => {
   const items = [
@@ -29,6 +33,55 @@ const StationNav = () => {
 
 const App = () => {
   const [wizardOpen, setWizardOpen] = useState(false);
+  const [consoleOpen, setConsoleOpen] = useState(false);
+  const [widgetReady, setWidgetReady] = useState(false);
+  const defaultStation = import.meta.env.VITE_AGENTKIT_DEFAULT_STATION_CONTEXT ?? 'toc-s1';
+  const chatkitConfigured = Boolean(
+    import.meta.env.VITE_CHATKIT_API_KEY &&
+      import.meta.env.VITE_AGENTKIT_ORG_ID &&
+      import.meta.env.VITE_CHATKIT_WIDGET_URL,
+  );
+  const { data: telemetryEvents = [], isLoading: telemetryLoading } = useTelemetryEvents(defaultStation);
+  const { data: supabaseSession } = useSupabaseSession();
+
+  const supabaseCredentials = useMemo(() => {
+    if (!supabaseSession) {
+      return undefined;
+    }
+
+    return {
+      accessToken: supabaseSession.access_token,
+      refreshToken: supabaseSession.refresh_token,
+      userId: supabaseSession.user?.id,
+    };
+  }, [supabaseSession]);
+
+  const telemetryContext = useMemo(() => {
+    const events = telemetryEvents ?? [];
+    const lastEventTimestamp = events.reduce<string | undefined>((latest, event) => {
+      if (!event.received_at) {
+        return latest;
+      }
+
+      if (!latest) {
+        return event.received_at;
+      }
+
+      const current = new Date(event.received_at).getTime();
+      const previous = new Date(latest).getTime();
+      return current > previous ? event.received_at : latest;
+    }, undefined);
+
+    return {
+      events,
+      lastEventTimestamp,
+      defaultStation,
+      credentials: supabaseCredentials,
+    };
+  }, [defaultStation, supabaseCredentials, telemetryEvents]);
+
+  const chatConsoleLoading = consoleOpen && (!widgetReady || telemetryLoading);
+
   return (
     <div className="station-shell">
       <header className="station-header">
@@ -41,11 +94,35 @@ const App = () => {
         >
           Launch setup wizard
         </button>
+        {chatkitConfigured ? (
+          <button
+            type="button"
+            className="setup-wizard__trigger"
+            onClick={() => setConsoleOpen((value) => !value)}
+          >
+            {consoleOpen ? 'Hide operations console' : 'Open operations console'}
+          </button>
+        ) : null}
       </header>
       <main className="station-content">
         <AppRouter />
       </main>
       <SetupWizard open={wizardOpen} onClose={() => setWizardOpen(false)} />
+      {chatkitConfigured ? (
+        <aside className="chatkit-console" aria-live="polite">
+          {chatConsoleLoading ? (
+            <div className="chatkit-console__loading" role="status">
+              Loading operations console…
+            </div>
+          ) : null}
+          <ChatKitWidget
+            open={consoleOpen && !chatConsoleLoading}
+            telemetry={telemetryContext}
+            onReady={() => setWidgetReady(true)}
+            className="chatkit-console__widget"
+          />
+        </aside>
+      ) : null}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- connect ChatKitWidget to the application shell with Supabase session and telemetry context, including open/close controls and loading feedback
- expand ChatKitWidget tests to cover context hydration and visibility toggling
- document the environment variables required to enable the ChatKit console

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68f54d68debc8323b8f16594a163d647