### PR TITLE
Add mission timeline tool to station AgentKit catalog

### DIFF
--- a/backend/app/routers/stations/agentkit.py
+++ b/backend/app/routers/stations/agentkit.py
@@ -41,5 +41,42 @@ def station_agent_actions(
             method="POST",
             metadata={"model": "StationAssignmentCreate"},
         ),
+        schemas.AgentAction(
+            name="mission_timeline",
+            description=(
+                "Retrieve the station's consolidated mission timeline, including telemetry, "
+                "AgentKit summaries, and operator log entries."
+            ),
+            endpoint=f"/api/v1/stations/{station.slug}/mission-timeline",
+            method="GET",
+            metadata={
+                "path_params": {
+                    "station_slug": {
+                        "type": "string",
+                        "required": True,
+                        "description": "Slug identifying the station mission context.",
+                    }
+                },
+                "query": {
+                    "limit": {
+                        "type": "integer",
+                        "required": False,
+                        "default": 50,
+                        "minimum": 1,
+                        "description": (
+                            "Maximum number of timeline entries to return (newest first)."
+                        ),
+                    }
+                },
+                "response": {
+                    "type": "array",
+                    "description": (
+                        "Timeline entries ordered from newest to oldest. Each entry includes "
+                        "an identifier, occurrence timestamp, category, human-readable "
+                        "summary, and structured metadata payload when available."
+                    ),
+                },
+            },
+        ),
     ]
     return schemas.StationAgentCatalog(station=station, actions=actions)

--- a/backend/tests/test_station_agentkit.py
+++ b/backend/tests/test_station_agentkit.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.app.main import app
+from backend.app import schemas
+from backend.app.services.supabase import get_supabase_repository
+
+
+class DummySupabaseRepository:
+    def __init__(self) -> None:
+        self.returned_stations: list[str] = []
+
+    def get_station(self, station_slug: str) -> schemas.StationRead:
+        self.returned_stations.append(station_slug)
+        now = datetime.utcnow()
+        return schemas.StationRead(
+            id=1,
+            slug=station_slug,
+            name="Test Station",
+            description="Testing station",
+            timezone="UTC",
+            telemetry_schema="test_schema",
+            created_at=now,
+            updated_at=now,
+        )
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    test_client = TestClient(app)
+    repo = DummySupabaseRepository()
+    app.dependency_overrides[get_supabase_repository] = lambda: repo
+    try:
+        yield test_client
+    finally:
+        app.dependency_overrides.pop(get_supabase_repository, None)
+        test_client.close()
+
+
+def test_agentkit_catalog_includes_mission_timeline(client: TestClient) -> None:
+    response = client.get("/api/v1/stations/demo/agentkit/actions")
+    assert response.status_code == 200
+    payload = response.json()
+    action_names = {action["name"] for action in payload["actions"]}
+    assert "mission_timeline" in action_names
+
+    timeline_action = next(
+        action for action in payload["actions"] if action["name"] == "mission_timeline"
+    )
+    assert timeline_action["method"] == "GET"
+    assert timeline_action["endpoint"].endswith("/api/v1/stations/demo/mission-timeline")
+
+    metadata = timeline_action["metadata"]
+    assert metadata["path_params"]["station_slug"]["required"] is True
+    assert metadata["query"]["limit"]["default"] == 50
+    assert "Timeline entries ordered" in metadata["response"]["description"]

--- a/docs/IMPLEMENTATION_SUMMARY.md
+++ b/docs/IMPLEMENTATION_SUMMARY.md
@@ -34,6 +34,9 @@ This summary captures the major components that make up the ChatKit-augmented vT
 - ChatKit organizes channels per station and threads per mission.
 - Backend webhook normalizes messages, applies station role policies, and schedules AgentKit runs.
 - AgentKit executes playbooks declared in `agents/config/agentkit.yml`, publishing summaries back to ChatKit and the mission log.
+- Station AgentKit catalog exposes tools such as `mission_timeline`, which proxies
+  `/api/v1/stations/{slug}/mission-timeline` so automations can retrieve recent mission
+  events and log entries for context-aware prompts.
 - `scripts/setup.sh` provisions sandbox channels and stores their IDs inside `.env.station`.
 
 ## Infrastructure & automation


### PR DESCRIPTION
## Summary
- expose a `mission_timeline` action in the station AgentKit catalog with path/query metadata and response description
- add a FastAPI test client regression test to ensure the catalog includes the new action
- document the new mission timeline tool in the implementation summary station API notes

## Testing
- pytest -q *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68f54d6c7ba88323a242ac36409ff040