### PR TITLE
chore: publish compose manifest artifact in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,11 +97,17 @@ PY
             CLEAN_PATH="$CLEAN_PATH:$PY_DIR"
           fi
           export PATH="$CLEAN_PATH"
+          export VTOC_COMPOSE_FILENAME="$GITHUB_WORKSPACE/docker-compose.generated.yml"
           if command -v terraform >/dev/null 2>&1; then
             echo "Terraform still available on PATH" >&2
             exit 1
           fi
           ./scripts/setup_container.sh --build-local
+      - name: Upload generated compose artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-compose-generated
+          path: '${{ github.workspace }}/docker-compose.generated.yml'
       - name: Install Python dependencies
         run: python -m pip install -r backend/requirements.runtime.txt -r backend/requirements.dev.txt
       - name: Python lint

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -57,6 +57,11 @@ For air-gapped development, set `USE_LOCAL_POSTGRES=1` before running the setup 
 
 ## Docker Compose (development + testing)
 
+CI runs on the `CI` workflow now upload the generated manifest as an artifact named
+`docker-compose-generated`. Download it from the workflow run to reuse the
+compose bundle emitted by `scripts/setup_container.sh --build-local` without
+rerunning the generator locally.
+
 1. Generate the compose file and role secrets:
    ```bash
    python -m scripts.bootstrap_cli setup container --apply


### PR DESCRIPTION
## Summary
- export the generated compose manifest to the GitHub workspace during CI runs
- upload the compose manifest as a `docker-compose-generated` workflow artifact
- document the new artifact location in the deployment guide

## Testing
- act workflow_dispatch -W .github/workflows/ci.yml -n *(fails: Docker Engine socket not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f54d74071c8323879f0c697ff7c970