### PR TITLE
ci: run alembic migrations per station schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,65 @@ on:
   workflow_dispatch:
 
 jobs:
+  alembic-migrations:
+    name: Alembic migrations (${{ matrix.station.slug }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        station:
+          - slug: toc-s1
+            schema: toc_s1
+          - slug: toc-s2
+            schema: toc_s2
+          - slug: toc-s3
+            schema: toc_s3
+          - slug: toc-s4
+            schema: toc_s4
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: vtoc
+          POSTGRES_USER: vtoc
+          POSTGRES_PASSWORD: vtocpass
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U vtoc"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install Alembic dependencies
+        run: python -m pip install -r backend/requirements.runtime.txt
+      - name: Ensure schema exists
+        env:
+          BASE_DATABASE_URL: postgresql+psycopg2://vtoc:vtocpass@localhost:5432/vtoc
+          TARGET_SCHEMA: ${{ matrix.station.schema }}
+        run: |
+          python - <<'PY'
+          import os
+          from sqlalchemy import create_engine, text
+
+          engine = create_engine(os.environ["BASE_DATABASE_URL"], future=True)
+          schema = os.environ["TARGET_SCHEMA"]
+
+          with engine.begin() as connection:
+              connection.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{schema}"'))
+          PY
+      - name: Run Alembic upgrade
+        working-directory: backend
+        env:
+          POSTGRES_STATION_ROLE: ${{ matrix.station.slug }}
+          DATABASE_URL: postgresql+psycopg2://vtoc:vtocpass@localhost:5432/vtoc?options=-csearch_path%3D${{ matrix.station.schema }}
+        run: alembic upgrade head
+
   build-and-test:
     permissions:
       packages: ${{ github.event_name == 'push' && 'write' || 'read' }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,7 @@ frontend/
 
 - Always create migrations for schema updates: `alembic revision --autogenerate -m "message"`.
 - Run `alembic upgrade head` for each station role or use the helper loop documented in [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md#multi-station-postgres).
+- Continuous integration runs `POSTGRES_STATION_ROLE`-scoped `alembic upgrade head` checks for every station schema, so make sure migrations succeed for each role before pushing.
 - Document breaking changes in [`docs/CHANGELOG.md`](docs/CHANGELOG.md).
 
 ### AgentKit / ChatKit integrations


### PR DESCRIPTION
## Summary
- add an alembic-migrations job that runs `alembic upgrade head` against toc-s1 through toc-s4 using a PostgreSQL service
- create each schema before applying migrations so the matrix can bootstrap fresh databases
- document the new CI check in the contributor guide so authors verify migrations per station

## Testing
- not run (requires GitHub Actions)

------
https://chatgpt.com/codex/tasks/task_e_68f54d778b908323a94902023bf58891