### PR TITLE
Add Terraform variable for mission timeline limits

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -27,6 +27,13 @@ When `terraform output -json fly_secret_map` is rendered these keys are now incl
 allowing operators to push consistent secrets into Fly.io or other target platforms.
 Override any value within `terraform.tfvars` or environment-specific tfvars files.
 
+### Mission timeline configuration
+
+The backend exposes a `timeline_event_limit` variable that caps the number of mission
+timeline events returned in API responses. Adjust the default of `100` to trim payloads or
+increase retention when exporting telemetry. The value is surfaced to Fly.io as the
+`MISSION_TIMELINE_LIMIT` secret so runtime deployments stay aligned with Terraform state.
+
 ## Udev rules for telemetry devices
 
 Udev rules under `deploy/udev/99-vtoc.rules` grant non-root access to USB serial adapters

--- a/infrastructure/terraform.tfvars.example
+++ b/infrastructure/terraform.tfvars.example
@@ -9,6 +9,9 @@ postgres_host           = "db.vtoc.supabase.co"
 postgres_internal_host  = "database"
 backend_public_base_url = "https://api.vtoc.pr-cybr.live"
 
+# Backend behavior
+timeline_event_limit = 100
+
 # Frontend defaults
 frontend_port            = 5173
 frontend_map_tiles_url   = "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"

--- a/infrastructure/terraform/secrets.tf
+++ b/infrastructure/terraform/secrets.tf
@@ -71,6 +71,7 @@ locals {
       AGENTKIT_API_KEY        = var.agentkit_api_key
       AGENTKIT_ORG_ID         = var.agentkit_org_id
       AGENTKIT_TIMEOUT_SECONDS = tostring(var.agentkit_timeout_seconds)
+      MISSION_TIMELINE_LIMIT  = tostring(var.timeline_event_limit)
       CHATKIT_WEBHOOK_SECRET  = var.chatkit_webhook_secret
       CHATKIT_ALLOWED_TOOLS   = join(",", var.chatkit_allowed_tools)
       CHATKIT_API_KEY         = var.chatkit_api_key

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -53,6 +53,12 @@ variable "backend_public_base_url" {
   type        = string
 }
 
+variable "timeline_event_limit" {
+  description = "Maximum number of timeline events the backend returns per mission."
+  type        = number
+  default     = 100
+}
+
 variable "frontend_port" {
   description = "Port used by the Vite dev server."
   type        = number


### PR DESCRIPTION
## Summary
- add a `timeline_event_limit` Terraform variable with a default of 100
- expose the value to Fly secrets as `MISSION_TIMELINE_LIMIT` so the backend can consume it
- document the new knob in the infrastructure README and example tfvars file

## Testing
- terraform -chdir=infrastructure/terraform validate *(fails: provider download blocked in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68f54d81e78c83239abab3c21183fd8f