### PR TITLE
Add Ansible automation for udev rules

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -30,6 +30,11 @@ Override any value within `terraform.tfvars` or environment-specific tfvars file
 ## Udev rules for telemetry devices
 
 Udev rules under `deploy/udev/99-vtoc.rules` grant non-root access to USB serial adapters
-and RTL-SDR receivers commonly used by the ingest services. Operators may add additional
-rules under `/etc/udev/rules.d/99-vtoc-local.rules` to tailor permissions for unique
+and RTL-SDR receivers commonly used by the ingest services. The Ansible deployment
+playbook now copies this rule into `/etc/udev/rules.d/99-vtoc.rules` and triggers a
+`udevadm control --reload` so that new permissions are active immediately. Stations that
+need hardware-specific tweaks can override the `vtoc_udev_rule_src` Ansible variable (for
+example within `inventory.ini`, `group_vars/`, or `host_vars/`) to point at a station
+specific file while retaining the shared automation. Additional local rules may still be
+added under `/etc/udev/rules.d/99-vtoc-local.rules` to tailor permissions for unique
 hardware revisions without modifying the shared rule set.

--- a/infrastructure/ansible/playbooks/deploy.yml
+++ b/infrastructure/ansible/playbooks/deploy.yml
@@ -7,6 +7,9 @@
   gather_facts: yes
   become: yes
 
+  vars_files:
+    - ../vars/defaults.yml
+
   vars:
     vtoc_home: "{{ ansible_env.HOME }}/vtoc"
     docker_compose_version: "2.23.0"
@@ -52,6 +55,15 @@
         dest: "{{ vtoc_home }}"
         mode: '0755'
 
+    - name: Install udev rule for telemetry devices
+      copy:
+        src: "{{ vtoc_udev_rule_src }}"
+        dest: /etc/udev/rules.d/99-vtoc.rules
+        owner: root
+        group: root
+        mode: '0644'
+      notify: Reload udev rules
+
     - name: Ensure station directories exist
       file:
         path: "{{ vtoc_home }}/stations/{{ item }}"
@@ -94,3 +106,7 @@
           - "Access the application at: http://localhost"
           - "Traefik Dashboard: http://localhost:8080"
           - "n8n Workflows: http://localhost/n8n"
+
+  handlers:
+    - name: Reload udev rules
+      command: udevadm control --reload

--- a/infrastructure/ansible/vars/defaults.yml
+++ b/infrastructure/ansible/vars/defaults.yml
@@ -1,0 +1,3 @@
+---
+# Default Ansible variables for vTOC infrastructure automation
+vtoc_udev_rule_src: "{{ playbook_dir }}/../../deploy/udev/99-vtoc.rules"


### PR DESCRIPTION
## Summary
- load shared default variables for the deployment playbook
- install the telemetry udev rule via Ansible and reload udev when it changes
- document the automation and how to override the rule location

## Testing
- ansible-playbook -i inventory.ini playbooks/deploy.yml --check *(fails: ansible-playbook not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f54d8504b48323bd58d8b73d7916d8